### PR TITLE
fix: keymapping defaults and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,15 @@ vim.api.nvim_set_keymap(
 | `<C-y>/y`        | Copy (multi-selected) files or folders to cwd        |
 | `<C-d>/dd`       | Delete (multi-selected) files or folders             |
 | `<C-r>/r`        | Rename (multi-selected) files                        |
+| `<C-e>/e`        | Add File/Folder at cwd; trailing `/` creates folder  |
 | `--/m`           | Move multi-selected files to cwd                     |
 | `<C-h>/h`        | Toggle hidden files                                  |
 | `<C-o>/o`        | Open file with default system application            |
+| `<C-g>/g`        | Go to parent directory                               |
 
 Copying and moving files first requires you to multi-select your files and folders and then moving to the target directory to copy and move the selections to (cf. [demo](#demo)). Renaming multi-selected files or folders launches batch renaming, which enables to user to rename or move multiple files at once, as moving files is analogous to renaming the file.
+
+As a tip: you can use telescope's `which_key` action mapped by default to `<C-/>` and `?` in insert and normal mode, respectively, to inspect the mappings attached to the picker from within telescope.
 
 ## Documentation
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -32,8 +32,7 @@ require "telescope".extensions.file_browser
 <
 In particular:
 - `file_browser`: constitutes the main picker of the extension
-- `picker`: unconfigured equivalent of `file_browser` defaulting to extensiond
-  defaults
+- `picker`: unconfigured equivalent of `file_browser`
 - `actions`: extension actions make accessible for remapping and custom usage
 - `finder`: low-level finders -- if you need to access them you know what you
   are doing
@@ -54,7 +53,7 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
     Default keymaps in insert/normal mode:
       - `<cr>`: opens the currently selected file, or navigates to the
         currently selected directory
-      - `<C-e>`: creates new file in current directory, creates new directory
+      - `<C-e/e>`: creates new file in current directory, creates new directory
         if the name contains a trailing '/'
         - Note: you can create files nested into several directories with
           `<C-e>`, i.e. `lua/telescope/init.lua` would create the file
@@ -68,7 +67,7 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
         current directory
       - `<C-f>/f`: toggle between file and folder browser
       - `<C-h>/h`: toggle hidden files
-      - `<C-d/dd>`: remove currently or multi selected file(s) or folder(s)
+      - `<C-d>/dd`: remove currently or multi selected file(s) or folder(s)
         recursively
       - --/m`: move multi selected file(s) or folder(s) recursively to current
         directory in file browser
@@ -193,8 +192,8 @@ fb_actions.open_file()                                *fb_actions.open_file()*
 
 
 
-fb_actions.goto_prev_dir({prompt_bufnr}, {bypass}) *fb_actions.goto_prev_dir()*
-    Goto previous directory in |builtin.file_browser|.
+fb_actions.goto_parent_dir({prompt_bufnr}, {bypass}) *fb_actions.goto_parent_dir()*
+    Goto parent directory in |builtin.file_browser|.
 
 
     Parameters: ~

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -356,10 +356,10 @@ fb_actions.open_file = function(prompt_bufnr)
   actions.close(prompt_bufnr)
 end
 
---- Goto previous directory in |builtin.file_browser|.
+--- Goto parent directory in |builtin.file_browser|.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param bypass boolean: Allow passing beyond the globally set current working directory
-fb_actions.goto_prev_dir = function(prompt_bufnr, bypass)
+fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
   bypass = vim.F.if_nil(bypass, true)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -14,13 +14,10 @@
 --- </code>
 ---@brief ]]
 
-local action_state = require "telescope.actions.state"
-local action_set = require "telescope.actions.set"
 local pickers = require "telescope.pickers"
 local conf = require("telescope.config").values
 
 local fb_finder = require "telescope._extensions.file_browser.finders"
-local fb_actions = require "telescope._extensions.file_browser.actions"
 
 local Path = require "plenary.path"
 local os_sep = Path.path.sep
@@ -31,7 +28,7 @@ local fb_picker = {}
 --- List, create, delete, rename, or move files and folders of your cwd.
 --- Default keymaps in insert/normal mode:
 ---   - `<cr>`: opens the currently selected file, or navigates to the currently selected directory
----   - `<C-e>`: creates new file in current directory, creates new directory if the name contains a trailing '/'
+---   - `<C-e/e>`: creates new file in current directory, creates new directory if the name contains a trailing '/'
 ---     - Note: you can create files nested into several directories with `<C-e>`, i.e. `lua/telescope/init.lua` would
 ---       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
 ---       `mkdir -p` would work) if they do not already exist
@@ -41,7 +38,7 @@ local fb_picker = {}
 ---   - `<C-y>/y`: copy multi selected file(s) or folder(s) recursively to current directory
 ---   - `<C-f>/f`: toggle between file and folder browser
 ---   - `<C-h>/h`: toggle hidden files
----   - `<C-d/dd>`: remove currently or multi selected file(s) or folder(s) recursively
+---   - `<C-d>/dd`: remove currently or multi selected file(s) or folder(s) recursively
 ---   - --/m`: move multi selected file(s) or folder(s) recursively to current directory in file browser
 ---@param opts table: options to pass to the picker
 ---@field path string: root dir to file_browse from (default: vim.loop.cwd())
@@ -63,53 +60,6 @@ fb_picker.file_browser = function(opts)
     finder = fb_finder.finder(opts),
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),
-    -- TODO(fdschmidt93): discuss tami's suggestion
-    on_input_filter_cb = function(prompt)
-      if prompt:sub(-1, -1) == os_sep then
-        local prompt_bufnr = vim.api.nvim_get_current_buf()
-        if vim.bo[prompt_bufnr].filetype == "TelescopePrompt" then
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          if current_picker.finder.files then
-            fb_actions.toggle_browser(prompt_bufnr, { reset_prompt = true })
-            current_picker:set_prompt(prompt:sub(1, -2))
-          end
-        end
-      end
-    end,
-    attach_mappings = function(prompt_bufnr, map)
-      action_set.select:replace_if(function()
-        -- test whether selected entry is directory
-        local selected_entry = action_state.get_selected_entry()
-        return selected_entry and selected_entry.path:sub(-1, -1) == os_sep
-      end, function()
-        local path = vim.loop.fs_realpath(action_state.get_selected_entry().path)
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        current_picker.results_border:change_title(Path:new(path):make_relative(cwd) .. os_sep)
-        local finder = current_picker.finder
-        finder.files = true
-        finder.path = path
-        current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
-      end)
-      map("i", "<C-e>", fb_actions.create_file)
-      map("n", "<C-e>", fb_actions.create_file)
-      map("i", "<C-r>", fb_actions.rename_file)
-      map("n", "<C-r>", fb_actions.rename_file)
-      map("i", "<C-o>", fb_actions.open_file)
-      map("n", "<C-o>", fb_actions.open_file)
-      map("i", "<C-y>", fb_actions.copy_file)
-      map("n", "y", fb_actions.copy_file)
-      map("i", "<C-h>", fb_actions.toggle_hidden)
-      map("n", "<h>", fb_actions.toggle_hidden)
-      map("i", "<C-g>", fb_actions.goto_prev_dir)
-      map("n", "g", fb_actions.goto_prev_dir)
-      map("i", "<C-f>", fb_actions.toggle_browser)
-      map("n", "f", fb_actions.toggle_browser)
-      map("i", "<C-w>", fb_actions.goto_cwd)
-      map("n", "m", fb_actions.move_file)
-      map("n", "dd", fb_actions.remove_file)
-      map("i", "<C-d>", fb_actions.remove_file)
-      return true
-    end,
   }):find()
 end
 


### PR DESCRIPTION
* Consistent default keymappings between insert and normal mode
* Fix being unable to fully override (unmap) default keymappings

This partially solves #5 as now mappings can be fully unmapped and overriden at telescope setup. What's still not possible is unmapping when called interactively eg

```lua
require "telescope".extensions.file_browser.file_browser {
  attach_mappings = function(prompt_bufnr, map)
    map("i", "<C-f>", false)
    return true
  end
}
```
which seems to be an upstream issue.

In any case, I prefer having the default configuration in `pconf` and it should largely fix the issue.

@j-hui could you please test whether this works for you? Many thanks in advance!