### PR TITLE
fix: hide "../" when in root dir

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -32,7 +32,9 @@ fb_finders.browse_files = function(opts)
       table.insert(data, typ == "directory" and (entry .. os_sep) or entry)
     end,
   })
-  table.insert(data, 1, ".." .. os_sep)
+  if opts.path ~= os_sep then
+    table.insert(data, 1, ".." .. os_sep)
+  end
   -- returns copy with properly set cwd for entry maker
   return finders.new_table { results = data, entry_maker = opts.entry_maker { cwd = opts.path } }
 end


### PR DESCRIPTION
Currently file_browser will always insert an "up dir" entry (../),
regardless of where it is in the filesystem

This change suppresses this entry if we are in the root directory (/)

Note I do not have access to Windows. I don't think \ is ever a
valid path in Windows, so don't believe this will have any adverse
affects on that OS, but I haven't been able to check specifically.