### PR TITLE
fix: results title on relative path

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -384,6 +384,10 @@ fb_actions.goto_cwd = function(prompt_bufnr)
   local finder = current_picker.finder
   finder.path = vim.loop.cwd() .. os_sep
   finder.files = true
+  if current_picker.results_border then
+    local new_title = Path:new(finder.path):make_relative(finder.path) .. os_sep
+    current_picker.results_border:change_title(new_title)
+  end
   current_picker:refresh(false, { reset_prompt = true })
 end
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -53,10 +53,11 @@ fb_picker.file_browser = function(opts)
   local cwd = vim.loop.cwd()
   opts.depth = vim.F.if_nil(opts.depth, 1)
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or cwd
+  opts.path = vim.F.if_nil(opts.path, cwd)
   opts.files = vim.F.if_nil(opts.files, true)
   pickers.new(opts, {
     prompt_title = opts.files and "File Browser" or "Folder Browser",
-    results_title = opts.files and Path:new(opts.cwd):make_relative(cwd) .. os_sep or "Results",
+    results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     finder = fb_finder.finder(opts),
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),


### PR DESCRIPTION
Ideally fixes #18 

@kascote could you please confirm whether this fixes your issue? The repro steps are incomplete since, if I understand correctly, you need to launch the file browser from a buffer within a sub-directory of `cwd` for the issue to occur as described.

