### PR TITLE
feat: change directory based on spcieal input paths

### DIFF
--- a/lua/telescope/_extensions/file_browser.lua
+++ b/lua/telescope/_extensions/file_browser.lua
@@ -85,15 +85,12 @@ local pconf = {
     },
   },
   on_input_filter_cb = function(prompt)
-    if prompt:sub(-1, -1) == os_sep then
+    if prompt == '~/' then
       local prompt_bufnr = vim.api.nvim_get_current_buf()
-      if vim.bo[prompt_bufnr].filetype == "TelescopePrompt" then
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        if current_picker.finder.files then
-          fb_actions.toggle_browser(prompt_bufnr, { reset_prompt = true })
-          current_picker:set_prompt(prompt:sub(1, -2))
-        end
-      end
+      fb_actions.goto_dir(prompt_bufnr, vim.env.HOME .. os_sep)
+    elseif prompt == '/' then
+      local prompt_bufnr = vim.api.nvim_get_current_buf()
+      fb_actions.goto_dir(prompt_bufnr, prompt)
     end
   end,
   attach_mappings = function(prompt_bufnr, _)


### PR DESCRIPTION
This change adds the following 2 special actions based on the input
path:

- If the user enters `~/` in the TelescopePrompt buffer, the
  file_browser is automatically changed to the user's `${HOME}`
directory

- If the user enters `/` in the TelescopePrompt buffer, the file_browser
  is automatically changed to the root directory (`/`)

The latter action (switching to root) clashes with the existing behaviour
where entering `/` into the TelescopePrompt buffer switches to the directory
browser.

Since this behaviour is also available under `<C-f>` (in insert mode) and
`f` (in normal mode), losing this special action was deemed acceptable.