### PR TITLE
feat: fd file and folder finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ use { "nvim-telescope/telescope-file-browser.nvim" }
 Plug "nvim-telescope/telescope-file-browser.nvim"
 ```
 
+### Optional Dependencies
+
+`telescope-file-browser` optionally levers [fd](https://github.com/sharkdp/fd) if installed primarily for more async but also generally faster file and folder browsing, which is most noticeable in larger repositories.
+
 # Setup and Configuration
 
 You configure the `telescope-file-browser` like any other `telescope.nvim` picker. See `:h telescope-file-browser.picker` for the full set of options dedicated to the picker. In addition, you of course can map `theme` and `mappings` as you are accustomed to from `telescope.nvim`.

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -245,3 +245,60 @@ fb_actions.select_all({prompt_bufnr})                *fb_actions.select_all()*
 
 
 
+================================================================================
+                                                *telescope-file-browser.finders*
+
+The file browser finders power the picker with both a file and folder browser.
+
+fb_finders.browse_files({opts})                    *fb_finders.browse_files()*
+    Returns a finder that is populated with files and folders in `path`. Notes:
+     - Uses `fd` if available for more async-ish browsing and speed-ups
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the finder
+
+    Fields: ~
+        {path}   (string)   root dir to browse from
+        {depth}  (number)   file tree depth to display (default: 1)
+        {hidden} (boolean)  determines whether to show hidden files or not
+                            (default: false)
+
+
+fb_finders.browse_folders({opts})                *fb_finders.browse_folders()*
+    Returns a finder that is populated with (sub-)folders of `cwd`. Notes:
+     - Uses `fd` if available for more async-ish browsing and speed-ups
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the finder
+
+    Fields: ~
+        {cwd}    (string)   root dir to browse from
+        {depth}  (number)   file tree depth to display (default: 1)
+        {hidden} (boolean)  determines whether to show hidden files or not
+                            (default: false)
+
+
+fb_finders.finder({opts})                                *fb_finders.finder()*
+    Returns a finder that combines |fb_finders.browse_files| and
+    |fb_finders.browse_folders| into a unified finder.
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+    Fields: ~
+        {path}     (string)   root dir to file_browse from (default:
+                              vim.loop.cwd())
+        {cwd}      (string)   root dir (default: vim.loop.cwd())
+        {files}    (boolean)  start in file (true) or folder (false) browser
+                              (default: true)
+        {depth}    (number)   file tree depth to display (default: 1)
+        {dir_icon} (string)   change the icon for a directory. (default: )
+        {hidden}   (boolean)  determines whether to show hidden files or not
+                              (default: false)
+
+
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -18,6 +18,8 @@ local os_sep = Path.path.sep
 local fb_finders = {}
 
 --- Returns a finder that is populated with files and folders in `path`.
+--- Notes:
+---  - Uses `fd` if available for more async-ish browsing and speed-ups
 ---@param opts table: options to pass to the finder
 ---@field path string: root dir to browse from
 ---@field depth number: file tree depth to display (default: 1)
@@ -58,6 +60,8 @@ fb_finders.browse_files = function(opts)
 end
 
 --- Returns a finder that is populated with (sub-)folders of `cwd`.
+--- Notes:
+---  - Uses `fd` if available for more async-ish browsing and speed-ups
 ---@param opts table: options to pass to the finder
 ---@field cwd string: root dir to browse from
 ---@field depth number: file tree depth to display (default: 1)

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -7,7 +7,7 @@ docs.test = function()
     "./lua/telescope/_extensions/file_browser.lua",
     "./lua/telescope/_extensions/file_browser/picker.lua",
     "./lua/telescope/_extensions/file_browser/actions.lua",
-    "./lua/telescope/_extensions/file_browser/finder.lua",
+    "./lua/telescope/_extensions/file_browser/finders.lua",
   }
 
   local output_file = "./doc/telescope-file-browser.txt"


### PR DESCRIPTION
Putting up the PR for users to see what'll land eventually.

Why is `fd` interesting?

* Speed: while `scandir` already is very fast, `fd` is faster and more importantly much, much more asyncish since it's off process
* `opts.depth=false` essentially acts as a mix of `find_{files, folders}`, extra speed may be worthwhile here
* Might be super cool to incorporate `--exec` (see `man fd`) in the future in some form (removing files by patterns etc. from within `nvim`)