### PR TITLE
fix: gitignore performance slowdown

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -78,16 +78,20 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}     (string)   root dir to file_browse from (default:
-                              vim.loop.cwd())
-        {cwd}      (string)   root dir (default: vim.loop.cwd())
-        {files}    (boolean)  start in file (true) or folder (false) browser
-                              (default: true)
-        {depth}    (number)   file tree depth to display, false for unlimited
-                              depth (default: 1)
-        {dir_icon} (string)   change the icon for a directory. (default: )
-        {hidden}   (boolean)  determines whether to show hidden files or not
-                              (default: false)
+        {path}              (string)   root dir to file_browse from (default:
+                                       vim.loop.cwd())
+        {cwd}               (string)   root dir (default: vim.loop.cwd())
+        {files}             (boolean)  start in file (true) or folder (false)
+                                       browser (default: true)
+        {depth}             (number)   file tree depth to display, false for
+                                       unlimited depth (default: 1)
+        {dir_icon}          (string)   change the icon for a directory.
+                                       (default: )
+        {hidden}            (boolean)  determines whether to show hidden files
+                                       or not (default: false)
+        {respect_gitignore} (boolean)  whether to respect_gitignore; induces
+                                       slow-down w/ plenary finder (default:
+                                       false)
 
 
 

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -27,6 +27,7 @@ fb_finders.browse_files = function(opts)
     add_dirs = opts.add_dirs,
     depth = opts.depth,
     hidden = opts.hidden,
+    respect_gitignore = opts.respect_gitignore,
   })
   if opts.path ~= os_sep then
     table.insert(data, 1, Path:new(opts.path):parent():absolute())
@@ -84,15 +85,13 @@ fb_finders.finder = function(opts)
     add_dirs = vim.F.if_nil(opts.add_dirs, true),
     hidden = vim.F.if_nil(opts.hidden, false),
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
-    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, true),
+    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, false), -- opt-in
     files = vim.F.if_nil(opts.files, true), -- file or folders mode
     -- ensure we forward make_entry opts adequately
     entry_maker = vim.F.if_nil(opts.entry_maker, function(local_opts)
       return fb_make_entry(vim.tbl_extend("force", opts, local_opts))
     end),
     _browse_files = vim.F.if_nil(opts.browse_files, fb_finders.browse_files),
-    -- lazy finder updated on hidden or cwd change
-    _cached_browse_folder = false,
     _browse_folders = vim.F.if_nil(opts.browse_folders, fb_finders.browse_folders),
   }, {
     __call = function(self, ...)

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -47,6 +47,7 @@ local fb_picker = {}
 ---@field depth number: file tree depth to display, false for unlimited depth (default: 1)
 ---@field dir_icon string: change the icon for a directory. (default: )
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
+---@field respect_gitignore boolean: whether to respect_gitignore; induces slow-down w/ plenary finder (default: false)
 fb_picker.file_browser = function(opts)
   opts = opts or {}
 


### PR DESCRIPTION
Closes #29.

`respect_gitignore` reduces plenary.scandir performance
10x and therefore now is opt-in.

This will be eventually alleviated with an fd-based finder.