### PR TITLE
fix: border = false error

### DIFF
--- a/lua/telescope/_extensions/file_browser.lua
+++ b/lua/telescope/_extensions/file_browser.lua
@@ -93,8 +93,12 @@ local pconf = {
     end, function()
       local path = vim.loop.fs_realpath(action_state.get_selected_entry().path)
       local current_picker = action_state.get_current_picker(prompt_bufnr)
-      current_picker.prompt_border:change_title "File Browser"
-      current_picker.results_border:change_title(Path:new(path):make_relative(current_picker.cwd) .. os_sep)
+      if current_picker.prompt_border then
+        current_picker.prompt_border:change_title "File Browser"
+      end
+      if current_picker.results_border then
+        current_picker.results_border:change_title(Path:new(path):make_relative(current_picker.cwd) .. os_sep)
+      end
       local finder = current_picker.finder
       finder.files = true
       finder.path = path


### PR DESCRIPTION
#31

When `defaults = { border = false }` selecting any directory results in an error