### PR TITLE
fix: ignore '..' and '.' during select/toggle all

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,6 +1,7 @@
 name: Generate docs
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - master

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -437,19 +437,14 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
   current_picker:refresh(finder, { reset_prompt = opts.reset_prompt, multi = current_picker._multi })
 end
 
-local function _get_ignore_values(current_picker)
-  local finder = current_picker.finder
-  local path_parent = tostring(Path:new(finder.path):parent())
-  return { "../", "./", path_parent, finder.path }
-end
-
 --- Toggles all selections akin to |actions.toggle_all| but ignores parent & current directory
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local ignore_values = _get_ignore_values(current_picker)
+  local finder = current_picker.finder
+  local parent_dir = tostring(Path:new(finder.path):parent())
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
-    if not vim.tbl_contains(ignore_values, entry.value) then
+    if not vim.tbl_contains({ finder.path, parent_dir }, entry.value) then
       current_picker._multi:toggle(entry)
       if current_picker:can_select_row(row) then
         current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
@@ -463,10 +458,11 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.select_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local ignore_values = _get_ignore_values(current_picker)
+  local finder = current_picker.finder
+  local parent_dir = tostring(Path:new(finder.path):parent())
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     if not current_picker._multi:is_selected(entry) then
-      if not vim.tbl_contains(ignore_values, entry.value) then
+      if not vim.tbl_contains({ finder.path, parent_dir }, entry.value) then
         current_picker._multi:add(entry)
         if current_picker:can_select_row(row) then
           current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -438,6 +438,7 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
 end
 
 --- Toggles all selections akin to |actions.toggle_all| but ignores parent & current directory
+--- - Note: if the parent or current directly was previously selected, they will be ignored in the selected state (manually unselect with `<TAB>`)
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
@@ -454,7 +455,9 @@ fb_actions.toggle_all = function(prompt_bufnr)
 end
 
 --- Multi select all entries akin to |actions.select_all| but ignores parent & current directory
---- - Note: selected entries may include results not visible in the results popup.
+--- - Note:
+---   - selected entries may include results not visible in the results popup.
+---   - if the parent or current directly was previously selected, they will be ignored in the selected state (manually unselect with `<TAB>`)
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.select_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -437,18 +437,19 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
   current_picker:refresh(finder, { reset_prompt = opts.reset_prompt, multi = current_picker._multi })
 end
 
-local function _ignore_values(current_picker)
+local function _get_ignore_values(current_picker)
   local finder = current_picker.finder
-  local parent_dir = tostring(Path:new(finder.path):parent())
-  return { "../", "./", parent_dir }
+  local path_parent = tostring(Path:new(finder.path):parent())
+  return { "../", "./", path_parent, finder.path }
 end
 
---- Toggles all selections akin to |actions.toggle_all| but ignores parent directory
+--- Toggles all selections akin to |actions.toggle_all| but ignores parent & current directory
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local ignore_values = _get_ignore_values(current_picker)
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
-    if not vim.tbl_contains(_ignore_values(current_picker), entry.value) then
+    if not vim.tbl_contains(ignore_values, entry.value) then
       current_picker._multi:toggle(entry)
       if current_picker:can_select_row(row) then
         current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
@@ -457,14 +458,15 @@ fb_actions.toggle_all = function(prompt_bufnr)
   end)
 end
 
---- Multi select all entries akin to |actions.select_all| but ignores parent directory
+--- Multi select all entries akin to |actions.select_all| but ignores parent & current directory
 --- - Note: selected entries may include results not visible in the results popup.
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.select_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local ignore_values = _get_ignore_values(current_picker)
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     if not current_picker._multi:is_selected(entry) then
-      if not vim.tbl_contains(_ignore_values(current_picker), entry.value) then
+      if not vim.tbl_contains(ignore_values, entry.value) then
         current_picker._multi:add(entry)
         if current_picker:can_select_row(row) then
           current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -439,7 +439,7 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
 end
 
 --- Toggles all selections akin to |actions.toggle_all| but ignores parent & current directory
---- - Note: if the parent or current directly was previously selected, they will be ignored in the selected state (manually unselect with `<TAB>`)
+--- - Note: if the parent or current directory were selected, they will be ignored (manually unselect with `<TAB>`)
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -437,13 +437,18 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
   current_picker:refresh(finder, { reset_prompt = opts.reset_prompt, multi = current_picker._multi })
 end
 
---- Toggles all selections akin to |actions.toggle_all| but ignores "../" and "./".
+local function _ignore_values(current_picker)
+  local finder = current_picker.finder
+  local parent_dir = tostring(Path:new(finder.path):parent())
+  return { "../", "./", parent_dir }
+end
+
+--- Toggles all selections akin to |actions.toggle_all| but ignores parent directory
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local ignore_values = { "../", "./" }
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
-    if not vim.tbl_contains(ignore_values, entry.value) then
+    if not vim.tbl_contains(_ignore_values(current_picker), entry.value) then
       current_picker._multi:toggle(entry)
       if current_picker:can_select_row(row) then
         current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
@@ -452,15 +457,14 @@ fb_actions.toggle_all = function(prompt_bufnr)
   end)
 end
 
---- Multi select all entries akin to |actions.select_all| but ignores "../" and "./".
+--- Multi select all entries akin to |actions.select_all| but ignores parent directory
 --- - Note: selected entries may include results not visible in the results popup.
 ---@param prompt_bufnr number: The prompt bufnr
 fb_actions.select_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local ignore_values = { "../", "./" }
   action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     if not current_picker._multi:is_selected(entry) then
-      if not vim.tbl_contains(ignore_values, entry.value) then
+      if not vim.tbl_contains(_ignore_values(current_picker), entry.value) then
         current_picker._multi:add(entry)
         if current_picker:can_select_row(row) then
           current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))


### PR DESCRIPTION
This should check off the third item in the med priority list in #3.

I didn't see any instances of `./` showing up anywhere so I didn't really consider them. Really only looked at preventing `../` from being selected.

I also left references to `../` and `./` in the `ignore_values` but I can remove them if needed.