### PR TITLE
rfc: Remove selected files user options (#13)

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -330,11 +330,7 @@ fb_actions.remove_file = function(prompt_bufnr)
   print "\n"
 
   vim.ui.input({ prompt = "Remove selected files [y/N]: " }, function(input)
-    if input == nil then
-      return
-    end
-    answer = string.lower(input)
-    if answer == "y" then
+    if input:lower() == "y" then
       for _, p in ipairs(selections) do
         local is_dir = p:is_dir()
         p:rm { recursive = is_dir }
@@ -344,9 +340,11 @@ fb_actions.remove_file = function(prompt_bufnr)
         else
           fb_utils.delete_dir_buf(p:absolute())
         end
-        a.nvim_notify(string.format("\n%s has been removed!", p:absolute()), vim.log.levels.INFO, {})
+        print(string.format("\n%s has been removed!", p:absolute()))
       end
       current_picker:refresh(current_picker.finder)
+    else
+      print("Removing files aborted!")
     end
   end)
 end

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -344,7 +344,7 @@ fb_actions.remove_file = function(prompt_bufnr)
       end
       current_picker:refresh(current_picker.finder)
     else
-      print("Removing files aborted!")
+      print(" Removing files aborted!")
     end
   end)
 end

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -344,7 +344,7 @@ fb_actions.remove_file = function(prompt_bufnr)
       end
       current_picker:refresh(current_picker.finder)
     else
-      print(" Removing files aborted!")
+      print " Removing files aborted!"
     end
   end)
 end

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -329,8 +329,12 @@ fb_actions.remove_file = function(prompt_bufnr)
   -- format printing adequately
   print "\n"
 
-  vim.ui.select({ "Yes", "No" }, { prompt = "Remove Selected Files" }, function(_, idx)
-    if idx == 1 then
+  vim.ui.input({ prompt = "Remove selected files [y/N]: " }, function(input)
+    if input == nil then
+      return
+    end
+    answer = string.lower(input)
+    if answer == "y" then
       for _, p in ipairs(selections) do
         local is_dir = p:is_dir()
         p:rm { recursive = is_dir }
@@ -340,7 +344,7 @@ fb_actions.remove_file = function(prompt_bufnr)
         else
           fb_utils.delete_dir_buf(p:absolute())
         end
-        print(string.format("%s has been removed!", p:absolute()))
+        a.nvim_notify(string.format("\n%s has been removed!", p:absolute()), vim.log.levels.INFO, {})
       end
       current_picker:refresh(current_picker.finder)
     end


### PR DESCRIPTION
This commit refactors the user options from the previous style:

  Remove Selected Files:
  1: Yes
  2: No
  Type number and <Enter> or click with the mouse (q or empty cancels):

To a more user-friendly and intuitive format:

  Remove selected files (Y/N):

Where the user can enter 'Y' or 'y' for 'Yes' and any other character
for 'No'.