### PR TITLE
FIX - Switch between file/folder mode (#43)

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -430,10 +430,6 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
     local new_title = finder.files and "File Browser" or "Folder Browser"
     current_picker.prompt_border:change_title(new_title)
   end
-  if current_picker.results_border then
-    local new_title = finder.files and Path:new(finder.path):make_relative(vim.loop.cwd()) .. os_sep or finder.cwd
-    current_picker.results_border:change_title(new_title)
-  end
   current_picker:refresh(finder, { reset_prompt = opts.reset_prompt, multi = current_picker._multi })
 end
 

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -71,7 +71,7 @@ end
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 fb_finders.browse_folders = function(opts)
   -- returns copy with properly set cwd for entry maker
-  local entry_maker = opts.entry_maker { cwd = opts.cwd }
+  local entry_maker = opts.entry_maker { cwd = opts.path }
   if has_fd then
     local args = { "-t", "d", "-a" }
     if opts.hidden then
@@ -85,16 +85,16 @@ fb_finders.browse_folders = function(opts)
         return { command = "fd", args = args }
       end,
       entry_maker = entry_maker,
-      results = { entry_maker(opts.cwd) },
-      cwd = opts.cwd,
+      results = { entry_maker(opts.path) },
+      cwd = opts.path,
     }
   else
-    local data = scan.scan_dir(opts.cwd, {
+    local data = scan.scan_dir(opts.path, {
       hidden = opts.hidden,
       only_dirs = true,
       respect_gitignore = opts.respect_gitignore,
     })
-    table.insert(data, 1, opts.cwd)
+    table.insert(data, 1, opts.path)
     return finders.new_table { results = data, entry_maker = entry_maker }
   end
 end


### PR DESCRIPTION
Before this commit, switching between file and folder browser mode
makes the finder return to the 'cwd' directory.

This behavior seems a bit odd, with this commit, instead of returning to
'cwd', the finder will remain in the current directory after switching
modes, this way the user can switch from file/folder mode without having
to navigate to the same directory again.

If a user wants to go back to 'cwd' they can always use 'C-W' to do
that.