### PR TITLE
fix: Incorrect file copied message (#37)

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -295,12 +295,23 @@ fb_actions.copy_file = function(prompt_bufnr)
       end
     end
     if destination ~= "" then -- vim.fn.input may return "" on cancellation
-      file:copy {
+      local res = file:copy {
         destination = destination,
         recursive = true,
         parents = true,
       }
-      print(string.format("\n%s has been copied!", filename))
+
+      for key, value in pairs(res) do
+        if key.filename == destination then
+          local res_msg
+          if res[key] then
+            res_msg = string.format("\n%s has been copied!", filename)
+          else
+            res_msg = string.format("\n%s has not been copied", filename)
+          end
+          a.nvim_echo({ { res_msg } }, false, {})
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When copying a file outside the original directory (cwd) the file is not
copied, this is expected, but the user still gets the following message:

  [file] has been copied!

This is incorrect, this commit fixes the issue by verifying the result
status from the copy operation and prints the appropriate message
'[file] has been copied!' or '[file] has not been copied' depending on
whether the operation succeeded or not.