### PR TITLE
feat: tie cwd of folder browser to file browser path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Please make sure to consult the docs prior to raising issues for asking question
 1. `file_browser`: find files and folders in the selected folder ("`path`", default: `cwd`)
 2. `folder_browser`: swiftly fuzzy select folders from `cwd` for file system operations
 
-The `folder_browser` currently always launches from `cwd` (default: neovim `cwd`), but will be made configurable to follow `path` rather than being launched from `cwd` every time.
+The `folder_browser` by always launches from `cwd` (default: neovim `cwd`), but can be configured to follow `path` of `file_browser` via the `cwd_to_path` option. The former corresponds to a more project-centric file browser workflow, whereas the latter typically facilitates file and folder browsing across the entire file system.
 
 In general, `telescope-file-browser.nvim` intends to enable any workflow without comprise via opting in as virtually any component can be overriden.
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -403,6 +403,8 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
 
   finder.path = parent_dir .. os_sep
   finder.files = true
+
+  fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
 
@@ -413,10 +415,8 @@ fb_actions.goto_cwd = function(prompt_bufnr)
   local finder = current_picker.finder
   finder.path = vim.loop.cwd() .. os_sep
   finder.files = true
-  if current_picker.results_border then
-    local new_title = Path:new(finder.path):make_relative(finder.path) .. os_sep
-    current_picker.results_border:change_title(new_title)
-  end
+
+  fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
 
@@ -429,10 +429,8 @@ fb_actions.change_cwd = function(prompt_bufnr)
   finder.path = entry_path:is_dir() and entry_path:absolute() or entry_path:parent():absolute()
   finder.cwd = finder.path
   vim.cmd("cd " .. finder.path)
-  if current_picker.results_border then
-    local title = Path:new(finder.path):make_relative(finder.path) .. os_sep
-    current_picker.results_border:change_title(title)
-  end
+
+  fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
   print "[telescope] Changed nvim's current working directory"
 end
@@ -443,10 +441,8 @@ fb_actions.goto_home_dir = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
   finder.path = vim.loop.os_homedir()
-  if current_picker.results_border then
-    local new_title = finder.files and Path:new(finder.path):make_relative(vim.loop.cwd()) .. os_sep or finder.cwd
-    current_picker.results_border:change_title(new_title)
-  end
+
+  fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
 
@@ -459,14 +455,7 @@ fb_actions.toggle_browser = function(prompt_bufnr, opts)
   local finder = current_picker.finder
   finder.files = not finder.files
 
-  if current_picker.prompt_border then
-    local new_title = finder.files and "File Browser" or "Folder Browser"
-    current_picker.prompt_border:change_title(new_title)
-  end
-  if current_picker.results_border then
-    local new_title = finder.files and Path:new(finder.path):make_relative(vim.loop.cwd()) .. os_sep or finder.cwd
-    current_picker.results_border:change_title(new_title)
-  end
+  fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = opts.reset_prompt, multi = current_picker._multi })
 end
 

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -71,7 +71,8 @@ end
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 fb_finders.browse_folders = function(opts)
   -- returns copy with properly set cwd for entry maker
-  local entry_maker = opts.entry_maker { cwd = opts.cwd }
+  local cwd = opts.cwd_to_path and opts.path or opts.cwd
+  local entry_maker = opts.entry_maker { cwd = cwd }
   if has_fd then
     local args = { "-t", "d", "-a" }
     if opts.hidden then
@@ -85,8 +86,8 @@ fb_finders.browse_folders = function(opts)
         return { command = "fd", args = args }
       end,
       entry_maker = entry_maker,
-      results = { entry_maker(opts.cwd) },
-      cwd = opts.cwd,
+      results = { entry_maker(cwd) },
+      cwd = cwd,
     }
   else
     local data = scan.scan_dir(opts.cwd, {
@@ -103,6 +104,7 @@ end
 ---@param opts table: options to pass to the picker
 ---@field path string: root dir to file_browse from (default: vim.loop.cwd())
 ---@field cwd string: root dir (default: vim.loop.cwd())
+---@field cwd_to_path bool: folder browser follows `path` of file browser
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field depth number: file tree depth to display (default: 1)
 ---@field dir_icon string: change the icon for a directory. (default: )
@@ -113,9 +115,9 @@ fb_finders.finder = function(opts)
   -- cache entries such that multi selections are maintained across {file, folder}_browsers
   -- otherwise varying metatables misalign selections
   opts.entry_cache = {}
-  opts.cwd = vim.F.if_nil(opts.cwd, vim.loop.cwd())
   return setmetatable({
-    cwd = opts.cwd, -- nvim cwd
+    cwd_to_path = opts.cwd_to_path,
+    cwd = opts.cwd_to_path and opts.path or opts.cwd, -- nvim cwd
     path = vim.F.if_nil(opts.path, opts.cwd), -- current path for file browser
     add_dirs = vim.F.if_nil(opts.add_dirs, true),
     hidden = vim.F.if_nil(opts.hidden, false),

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -53,6 +53,7 @@ fb_picker.file_browser = function(opts)
 
   local cwd = vim.loop.cwd()
   opts.depth = vim.F.if_nil(opts.depth, 1)
+  opts.cwd_to_path = vim.F.if_nil(opts.cwd_to_path, false)
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or cwd
   opts.path = opts.path and vim.fn.expand(opts.path) or opts.cwd
   opts.files = vim.F.if_nil(opts.files, true)

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -104,4 +104,22 @@ fb_utils.delete_dir_buf = function(dir)
   }
 end
 
+-- redraws prompt and results border contingent on picker status
+fb_utils.redraw_border_title = function(current_picker)
+  local finder = current_picker.finder
+  if current_picker.prompt_border then
+    local new_title = finder.files and "File Browser" or "Folder Browser"
+    current_picker.prompt_border:change_title(new_title)
+  end
+  if current_picker.results_border then
+    local new_title
+    if finder.files or finder.cwd_to_path then
+      new_title = Path:new(finder.path):make_relative(vim.loop.cwd())
+    else
+      new_title = finder.cwd
+    end
+    current_picker.results_border:change_title(new_title)
+  end
+end
+
 return fb_utils


### PR DESCRIPTION
Closes #43 

Supersedes #44 

* Refactor redrawing border titles to a utility function, we can always redraw more than needed
* Introduce `cwd_to_path` option to hook `folder_browser` to `file_browser` path rather than neovim `cwd`

Maybe we can introduce actions to toggle between the two modes, but this should be a good start.