### PR TITLE
feat: group dirs and files in file_browser

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -83,6 +83,9 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
         {cwd_to_path}       (boolean)   whether folder browser is launched
                                         from `path` rather than `cwd`
                                         (default: false)
+        {grouped}           (boolean)   group initial sorting by directories
+                                        and then files; uses plenary.scandir
+                                        (default: false)
         {files}             (boolean)   start in file (true) or folder (false)
                                         browser (default: true)
         {add_dirs}          (boolean)   whether the file browser shows folders
@@ -197,8 +200,8 @@ fb_actions.open()                                          *fb_actions.open()*
     Opens the file or folder with the default application.
 
     - Notes:
-      - map fb_actions.open + fb_actions.close if you want to close the
-        picker post-action
+      - map fb_actions.open + fb_actions.close if you want to close the picker
+        post-action
     - OS: make sure your OS links against the desired applications:
       - Linux: induces application via `xdg-open`
       - macOS: relies on `open` to start the program
@@ -328,6 +331,9 @@ fb_finders.finder({opts})                                *fb_finders.finder()*
                                        browser
         {files}             (boolean)  start in file (true) or folder (false)
                                        browser (default: true)
+        {grouped}           (boolean)  group initial sorting by directories
+                                       and then files; uses plenary.scandir
+                                       (default: false)
         {depth}             (number)   file tree depth to display (default: 1)
         {dir_icon}          (string)   change the icon for a directory.
                                        (default: )

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -29,7 +29,7 @@ fb_finders.browse_files = function(opts)
   opts = opts or {}
   -- returns copy with properly set cwd for entry maker
   local entry_maker = opts.entry_maker { cwd = opts.path }
-  if has_fd then
+  if has_fd and opts.sorted == false then
     local args = { "-a" }
     if opts.hidden then
       table.insert(args, "-H")
@@ -61,6 +61,21 @@ fb_finders.browse_files = function(opts)
     })
     if opts.path ~= os_sep then
       table.insert(data, 1, Path:new(opts.path):parent():absolute())
+    end
+    if opts.sorted then
+      table.sort(data, function(a, b)
+        local a_is_dir = vim.loop.fs_stat(a).type == "directory"
+        local b_is_dir = vim.loop.fs_stat(b).type == "directory"
+        if a_is_dir and b_is_dir then
+          return a < b
+        elseif a_is_dir and not b_is_dir then
+          return true
+        elseif not a_is_dir and b_is_dir then
+          return false
+        else
+          return a < b
+        end
+      end)
     end
     return finders.new_table { results = data, entry_maker = entry_maker }
   end

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -6,6 +6,7 @@
 --- The file browser finders power the picker with both a file and folder browser.
 ---@brief ]]
 
+local fb_utils = require "telescope._extensions.file_browser.utils"
 local fb_make_entry = require "telescope._extensions.file_browser.make_entry"
 
 local async_oneshot_finder = require "telescope.finders.async_oneshot_finder"
@@ -29,7 +30,7 @@ fb_finders.browse_files = function(opts)
   opts = opts or {}
   -- returns copy with properly set cwd for entry maker
   local entry_maker = opts.entry_maker { cwd = opts.path }
-  if has_fd and opts.sorted == false then
+  if has_fd and opts.grouped == false then
     local args = { "-a" }
     if opts.hidden then
       table.insert(args, "-H")
@@ -62,20 +63,8 @@ fb_finders.browse_files = function(opts)
     if opts.path ~= os_sep then
       table.insert(data, 1, Path:new(opts.path):parent():absolute())
     end
-    if opts.sorted then
-      table.sort(data, function(a, b)
-        local a_is_dir = vim.loop.fs_stat(a).type == "directory"
-        local b_is_dir = vim.loop.fs_stat(b).type == "directory"
-        if a_is_dir and b_is_dir then
-          return a < b
-        elseif a_is_dir and not b_is_dir then
-          return true
-        elseif not a_is_dir and b_is_dir then
-          return false
-        else
-          return a < b
-        end
-      end)
+    if opts.grouped then
+      fb_utils.group_by_type(data)
     end
     return finders.new_table { results = data, entry_maker = entry_maker }
   end
@@ -125,6 +114,7 @@ end
 ---@field cwd string: root dir (default: vim.loop.cwd())
 ---@field cwd_to_path bool: folder browser follows `path` of file browser
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
+---@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)
 ---@field depth number: file tree depth to display (default: 1)
 ---@field dir_icon string: change the icon for a directory. (default: )
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
@@ -143,6 +133,7 @@ fb_finders.finder = function(opts)
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
     respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode
+    grouped = vim.F.if_nil(opts.grouped, false),
     -- ensure we forward make_entry opts adequately
     entry_maker = vim.F.if_nil(opts.entry_maker, function(local_opts)
       return fb_make_entry(vim.tbl_extend("force", opts, local_opts))

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -45,6 +45,7 @@ local fb_picker = {}
 ---@field path string: dir to browse files from from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd string: dir to browse folders from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd_to_path boolean: whether folder browser is launched from `path` rather than `cwd` (default: false)
+---@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -122,4 +122,23 @@ fb_utils.redraw_border_title = function(current_picker)
   end
 end
 
+fb_utils.group_by_type = function(tbl)
+  table.sort(tbl, function(x, y)
+    local x_is_dir = vim.loop.fs_stat(x).type == "directory"
+    local y_is_dir = vim.loop.fs_stat(y).type == "directory"
+    -- if both are dir, "shorter" string of the two
+    if x_is_dir and y_is_dir then
+      return x < y
+      -- prefer directories
+    elseif x_is_dir and not y_is_dir then
+      return true
+    elseif not x_is_dir and y_is_dir then
+      return false
+      -- prefer "shorter" filenames
+    else
+      return x < y
+    end
+  end)
+end
+
 return fb_utils


### PR DESCRIPTION
As per reddit request. This PR introduces the `grouped` option which initially groups entries in the `file_browser` by directory and files and only then sorts alphabetically. I would probably mark this optional as this is behavior that cannot be easily achieved with an `fd` finder, but happy to be convinced otherwise.

`fd` is required for `depth=false` and fast folder browsing. For classic `file_browser`, `plenary.scandir` is already plenty fast.

Before:

![before](https://user-images.githubusercontent.com/39233597/149616389-97df9014-8f29-40a2-a2ca-fb32d37400e8.png)

After

![after](https://user-images.githubusercontent.com/39233597/149616393-1e763c69-2fc0-47e8-aa95-c5193590aba5.png)
