### PR TITLE
feat: terminal cmd preview for directories

### DIFF
--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -18,7 +18,7 @@ local pickers = require "telescope.pickers"
 local conf = require("telescope.config").values
 
 local fb_finder = require "telescope._extensions.file_browser.finders"
-
+local fb_previewer = require "telescope._extensions.file_browser.previewer"
 local Path = require "plenary.path"
 local os_sep = Path.path.sep
 
@@ -67,7 +67,7 @@ fb_picker.file_browser = function(opts)
     prompt_title = opts.files and "File Browser" or "Folder Browser",
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     finder = fb_finder.finder(opts),
-    previewer = conf.file_previewer(opts),
+    previewer = fb_previewer.previewer.new(opts),
     sorter = conf.file_sorter(opts),
   }):find()
 end

--- a/lua/telescope/_extensions/file_browser/previewer.lua
+++ b/lua/telescope/_extensions/file_browser/previewer.lua
@@ -1,0 +1,77 @@
+local from_entry = require "telescope.from_entry"
+local Path = require "plenary.path"
+local conf = require("telescope.config").values
+
+local fb_previewer = {}
+local buffer_previewer = require("telescope.previewers.buffer_previewer").cat
+local term_previewer = require "telescope.previewers.term_previewer"
+
+local action_state = require "telescope.actions.state"
+
+local function defaulter(f, default_opts)
+  default_opts = default_opts or {}
+  return {
+    new = function(opts)
+      if conf.preview == false and not opts.preview then
+        return false
+      end
+      opts.preview = type(opts.preview) ~= "table" and {} or opts.preview
+      if type(conf.preview) == "table" then
+        for k, v in pairs(conf.preview) do
+          opts.preview[k] = vim.F.if_nil(opts.preview[k], v)
+        end
+      end
+      return f(opts)
+    end,
+    __call = function()
+      local ok, err = pcall(f(default_opts))
+      if not ok then
+        error(debug.traceback(err))
+      end
+    end,
+  }
+end
+
+fb_previewer.previewer = defaulter(function(opts)
+  return setmetatable({
+    _buffer_previewer = buffer_previewer.new(opts),
+    _term_previewer = term_previewer.new_termopen_previewer {
+      get_command = function(entry)
+        local p = from_entry.path(entry, true)
+        if p == nil or p == "" then
+          return
+        end
+        return opts.dir_preview(p)
+      end,
+    },
+    preview = function(self, entry, status)
+      if opts.dir_preview and entry and entry.Path:is_dir() then
+        self._term_previewer.preview(self._term_previewer, entry, status)
+      else
+        self._buffer_previewer.preview(self._buffer_previewer, entry, status)
+      end
+    end,
+    scroll_fn = function(self, direction)
+      local entry = action_state.get_selected_entry()
+      if opts.dir_preview and entry and entry.Path:is_dir() then
+        self._term_previewer.scroll_fn(self._term_previewer, direction)
+      else
+        self._buffer_previewer.scroll_fn(self._buffer_previewer, direction)
+      end
+    end,
+    teardown = function(self)
+      if self._buffer_previewer._teardown_func then
+        self._buffer_previewer._teardown_func(self._buffer_previewer)
+      end
+      if self._term_previewer._teardown_func then
+        self._term_previewer._teardown_func(self._term_previewer)
+      end
+    end,
+  }, {
+    __index = function(self, key, ...)
+      return self._buffer_previewer[key]
+    end,
+  })
+end, {})
+
+return fb_previewer

--- a/lua/telescope/_extensions/file_browser/previewer.lua
+++ b/lua/telescope/_extensions/file_browser/previewer.lua
@@ -65,6 +65,12 @@ fb_previewer.previewer = defaulter(function(opts)
       end
       if self._term_previewer._teardown_func then
         self._term_previewer._teardown_func(self._term_previewer)
+        -- TODO: hacky workaround
+        if opts.dir_preview then
+          vim.schedule(function()
+            vim.cmd [[ stopinsert ]]
+          end)
+        end
       end
     end,
   }, {


### PR DESCRIPTION
Ah, this is a tricky one. This allows overwriting the directory previewer with a function like so

```lua
function(path)
  return "ls -la --color=always " .. path .. " | less -r"
end
```

would show `ls -la` output like in the terminal

The video shows `tree` as a previewer. Colors may or may not work depending on compatability with a pager.

https://user-images.githubusercontent.com/39233597/149843316-89d4e917-aefe-4fa0-bb50-94cc9e401730.mp4

I hope someone appreciates this hack :laughing: 