### PR TITLE
feat: creating, copying & moving in folder_browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Note: `path` corresponds to the folder the `file_browser` is currently in.
 
 **Warning:** Batch renaming or moving files with path inter-dependencies are not resolved! For instance, moving a folder somewhere while moving another file into the original folder in later order within same action will fail.
 
-| Action (incl. GIF)| Docs                   | Comment  |
-|-------------------|------------------------|----------| 
-|  [creation](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010221098)| `:h fb_action.create`| Levers `vim.ui.input`, trailing path separator (e.g. `/` on unix) creates folder |
-|  [copying](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010298556) | `:h fb_action.copy`  | Supports copying current selection in `path` & multi-selections to respective `path` |
-|  [moving](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010301465)  | `:h fb_action.move`  | Move multi-selected files to `path` |
+| Action (incl. GIF)| Docs                   | Comment |
+|-------------------|------------------------|---------| 
+|  [creation](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010221098)| `:h fb_action.create`| Create file or folder (with trailing OS separator) at `path` (`file_browser`) or at selected directory (`folder_browser`)|
+|  [copying](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010298556) | `:h fb_action.copy`  | Supports copying current selection & multi-selections to `path` (`file_browser`) or selected directory (`folder_browser`) |
+|  [moving](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010301465)  | `:h fb_action.move`  | Move multi-selected files to `path` (`file_browser`) or selected directory (`folder_browser`) |
 |  [removing](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010315578)| `:h fb_action.remove`| Remove (multi-)selected files |
 |  [renaming](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010323053)| `:h fb_action.rename`| Rename (multi-)selected files |
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -135,11 +135,15 @@ require('telescope').setup {
 
 fb_actions.create({prompt_bufnr})                        *fb_actions.create()*
     Creates a new file in the current directory of the
-    |fb_picker.file_browser|. Notes:
-    - You can create folders by ending the name in the path separator of your
-      OS, e.g. "/" on Unix systems
-    - You can implicitly create new folders by passing
-      $/CWD/new_folder/filename.lua
+    |fb_picker.file_browser|.
+    - Finder:
+      - file_browser: create a file in the currently opened directory
+      - folder_browser: create a file in the currently selected directory
+    - Notes:
+      - You can create folders by ending the name in the path separator of your
+        OS, e.g. "/" on Unix systems
+      - You can implicitly create new folders by passing
+        $/CWD/new_folder/filename.lua
 
 
     Parameters: ~
@@ -172,7 +176,12 @@ fb_actions.move({prompt_bufnr})                            *fb_actions.move()*
 fb_actions.copy({prompt_bufnr})                            *fb_actions.copy()*
     Copy file or folders recursively to current directory in
     |fb_picker.file_browser|.
-    Note: Performs a blocking synchronized file-system operation.
+
+    - Finder:
+      - file_browser: copies (multi-selected) file(s) in/to opened dir (w/o
+        multi-selection, creates in-place copy)
+      - folder_browser: copies (multi-selected) file(s) in/to selected dir (w/o
+        multi-selection, creates in-place copy)
 
 
     Parameters: ~


### PR DESCRIPTION
Closes #78 

This commit enables creating, copying, and moving
files and folders from within folder_browser mode.

In doing so, the currently selected directory within
folder_browser serves as the target directory for the
corresponding telescope-file-browser action.