### PR TITLE
fix: consistent gitignore handling between plenary & fd

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -96,9 +96,8 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
                                         (default: )
         {hidden}            (boolean)   determines whether to show hidden
                                         files or not (default: false)
-        {respect_gitignore} (boolean)   induces slow-down w/ plenary finder
-                                        (default: false, true if `fd`
-                                        available)
+        {respect_gitignore} (boolean)   can induce slow-down w/ plenary finder
+                                        (default: true)
         {browse_files}      (function)  custom override for the file browser
                                         (default: |fb_finders.browse_files|)
         {browse_folders}    (function)  custom override for the folder browser

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -59,6 +59,7 @@ fb_finders.browse_files = function(opts)
       add_dirs = opts.add_dirs,
       depth = opts.depth,
       hidden = opts.hidden,
+      respect_gitignore = opts.respect_gitignore,
     })
     if opts.path ~= os_sep then
       table.insert(data, 1, Path:new(opts.path):parent():absolute())
@@ -131,7 +132,7 @@ fb_finders.finder = function(opts)
     add_dirs = vim.F.if_nil(opts.add_dirs, true),
     hidden = vim.F.if_nil(opts.hidden, false),
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
-    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),
+    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, true),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode
     grouped = vim.F.if_nil(opts.grouped, false),
     -- ensure we forward make_entry opts adequately

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -51,7 +51,7 @@ local fb_picker = {}
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
----@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
+---@field respect_gitignore boolean: can induce slow-down w/ plenary finder (default: true)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)
 fb_picker.file_browser = function(opts)


### PR DESCRIPTION
Maybe fixes #83 

E: I don't know, might be a plenary bug. I'll revisit later this week. Not super quick fix.

E2: `:lua print(vim.inspect(require "plenary.scandir".scan_dir(vim.loop.cwd(), { respect_gitignore = true, depth = 1, add_dirs = true })))` ~~in a directory with a `gitignore`d folder~~ showcases the bug.

E3: This affects `~/.config/git/ignore`