### PR TITLE
close #95: add option `select_buffer`

### DIFF
--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -37,7 +37,7 @@ local get_selection_index = function(opts, results)
       end
     end
   end
-  return 1
+  return vim.F.if_nil(opts.default_selection_index, 1)
 end
 
 --- List, create, delete, rename, or move files and folders of your cwd.

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -30,16 +30,13 @@ local get_selection_index = function(opts, results)
   local buf_path = vim.api.nvim_buf_get_name(0)
   local current_dir = Path:new(buf_path):parent():absolute()
 
-  if opts.path ~= current_dir then
-    return 1
-  end
-
-  for i, path_entry in ipairs(results) do
-    if path_entry.value == buf_path then
-      return i
+  if opts.path == current_dir then
+    for i, path_entry in ipairs(results) do
+      if path_entry.value == buf_path then
+        return i
+      end
     end
   end
-
   return 1
 end
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -67,6 +67,7 @@ end
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
+---@field select_buffer boolean: whether to select opened buffer if possible; may imply `hidden=true`. (default: false)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
@@ -86,9 +87,9 @@ fb_picker.file_browser = function(opts)
   opts.hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
 
-  local select_buffer = opts.select_buffer and opts.files and opts.depth == 1
+  local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
-  opts.hidden = (select_buffer and vim.fn.expand('%:p:t'):sub(1, 1) == '.') and true or opts.hidden
+  opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == '.') and true or opts.hidden
   local finder = fb_finder.finder(opts)
   -- find index of current buffer in the results
   if select_buffer then

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -64,7 +64,7 @@ end
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
----@field select_buffer boolean: whether to select opened buffer if possible; may imply `hidden=true` (default: false)
+---@field select_buffer boolean: select current buffer if possible; may imply `hidden=true` (default: false)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
@@ -85,11 +85,11 @@ fb_picker.file_browser = function(opts)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
 
   local select_buffer = opts.select_buffer and opts.files
-  -- handle case that current buffer is a hidden file
-  opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
   local finder = fb_finder.finder(opts)
   -- find index of current buffer in the results
   if select_buffer then
+    -- handle case that current buffer is a hidden file
+    opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
     finder._finder = finder:_browse_files()
     opts.default_selection_index = get_selection_index(opts, finder.results)
   end

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -85,11 +85,11 @@ fb_picker.file_browser = function(opts)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
 
   local select_buffer = opts.select_buffer and opts.files
+  -- handle case that current buffer is a hidden file
+  opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
   local finder = fb_finder.finder(opts)
   -- find index of current buffer in the results
   if select_buffer then
-    -- handle case that current buffer is a hidden file
-    opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
     finder._finder = finder:_browse_files()
     opts.default_selection_index = get_selection_index(opts, finder.results)
   end

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -67,7 +67,7 @@ end
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
----@field select_buffer boolean: whether to select opened buffer if possible; may imply `hidden=true`. (default: false)
+---@field select_buffer boolean: whether to select opened buffer if possible; may imply `hidden=true` (default: false)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
@@ -89,7 +89,7 @@ fb_picker.file_browser = function(opts)
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
-  opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == '.') and true or opts.hidden
+  opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
   local finder = fb_finder.finder(opts)
   -- find index of current buffer in the results
   if select_buffer then


### PR DESCRIPTION
If the option is set to `true`, file browser will try to select the
current buffer at start. It has no effect if `opts.path` or `opts.cwd`
is not the parent directory of the current buffer or `opts.depth` is
greater than 1 or the initial mode is not `file`.

Closes #95 