### PR TITLE
feat: add option `add_files`

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -90,6 +90,8 @@ fb_picker.file_browser({opts})                      *fb_picker.file_browser()*
                                         browser (default: true)
         {add_dirs}          (boolean)   whether the file browser shows folders
                                         (default: true)
+        {add_files}         (boolean)   whether the file browser shows files
+                                        (default: true)
         {depth}             (number)    file tree depth to display, `false`
                                         for unlimited depth (default: 1)
         {dir_icon}          (string)    change the icon for a directory

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -39,7 +39,11 @@ fb_finders.browse_files = function(opts)
     if opts.respect_gitignore == false then
       table.insert(args, "--no-ignore-vcs")
     end
-    if opts.add_dirs == false then
+    if opts.add_dirs then
+      table.insert(args, "--type")
+      table.insert(args, "directory")
+    end
+    if opts.add_files then
       table.insert(args, "--type")
       table.insert(args, "file")
     end
@@ -58,6 +62,7 @@ fb_finders.browse_files = function(opts)
   else
     local data = scan.scan_dir(opts.path, {
       add_dirs = opts.add_dirs,
+      add_files = opts.add_files,
       depth = opts.depth,
       hidden = opts.hidden,
     })
@@ -131,6 +136,7 @@ fb_finders.finder = function(opts)
     cwd = opts.cwd_to_path and opts.path or opts.cwd, -- nvim cwd
     path = vim.F.if_nil(opts.path, opts.cwd), -- current path for file browser
     add_dirs = vim.F.if_nil(opts.add_dirs, true),
+    add_files = vim.F.if_nil(opts.add_files, true),
     hidden = vim.F.if_nil(opts.hidden, false),
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
     respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -48,6 +48,7 @@ local fb_picker = {}
 ---@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
+---@field add_files boolean: whether the file browser shows files (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)


### PR DESCRIPTION
I have this use case, where I want to be able to chain file_browser with other pickers like live_grep or find_files. The idea is that I could first select a folder using file_browser and then set the folder path to `cwd` in live_grep or find_files options. This option allows to only show folders when `add_files == false`. Of course, because `<CR>` opens a folder, some other key mapping is needed to actually select the folder.