### PR TITLE
Fixes problem with using the wrong check to determine if on Windows or not

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -383,7 +383,7 @@ fb_actions.open = function(prompt_bufnr)
     return
   end
 
-  local cmd = vim.fn.has "win-32" == 1 and "start" or vim.fn.has "mac" == 1 and "open" or "xdg-open"
+  local cmd = vim.fn.has "win32" == 1 and "start" or vim.fn.has "mac" == 1 and "open" or "xdg-open"
   for _, selection in ipairs(selections) do
     require("plenary.job")
       :new({


### PR DESCRIPTION
win-32 always return 0 on windows as the correct check is win32. This fixes the problem I ran into with not being able to use the open function