### PR TITLE
feat: enable hijacking of netrw on vim startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The demo shows multi-selecting files across various folders and then moving them
 
 # Installation
 
-## packer 
+## packer
 
 ```lua
 use { "nvim-telescope/telescope-file-browser.nvim" }
 ```
 
-## Vim-Plug 
+## Vim-Plug
 
 ```viml
 Plug 'nvim-telescope/telescope-file-browser.nvim'
@@ -37,6 +37,7 @@ require("telescope").setup {
   extensions = {
     file_browser = {
       theme = "ivy",
+      hijack_netrw = true, -- disables netrw and use telescope file browser in its place
       mappings = {
         ["i"] = {
           -- your custom insert mode mappings
@@ -113,7 +114,7 @@ Note: `path` corresponds to the folder the `file_browser` is currently in.
 **Warning:** Batch renaming or moving files with path inter-dependencies are not resolved! For instance, moving a folder somewhere while moving another file into the original folder in later order within same action will fail.
 
 | Action (incl. GIF)| Docs                   | Comment |
-|-------------------|------------------------|---------| 
+|-------------------|------------------------|---------|
 |  [creation](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010221098)| `:h telescope-file-browser.actions.create`| Create file or folder (with trailing OS separator) at `path` (`file_browser`) or at selected directory (`folder_browser`)|
 |  [copying](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010298556) | `:h telescope-file-browser.actions.copy`  | Supports copying current selection & multi-selections to `path` (`file_browser`) or selected directory (`folder_browser`) |
 |  [moving](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53#issuecomment-1010301465)  | `:h telescope-file-browser.actions.move`  | Move multi-selected files to `path` (`file_browser`) or selected directory (`folder_browser`) |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ require("telescope").setup {
   extensions = {
     file_browser = {
       theme = "ivy",
-      hijack_netrw = true, -- disables netrw and use telescope file browser in its place
+      -- disables netrw and use telescope-file-browser in its place
+      hijack_netrw = true,
       mappings = {
         ["i"] = {
           -- your custom insert mode mappings

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -96,48 +96,54 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}              (string)      dir to browse files from from,
-                                          `vim.fn.expanded` automatically
-                                          (default: vim.loop.cwd())
-        {cwd}               (string)      dir to browse folders from,
-                                          `vim.fn.expanded` automatically
-                                          (default: vim.loop.cwd())
-        {cwd_to_path}       (boolean)     whether folder browser is launched
-                                          from `path` rather than `cwd`
-                                          (default: false)
-        {grouped}           (boolean)     group initial sorting by directories
-                                          and then files; uses plenary.scandir
-                                          (default: false)
-        {files}             (boolean)     start in file (true) or folder
-                                          (false) browser (default: true)
-        {add_dirs}          (boolean)     whether the file browser shows
-                                          folders (default: true)
-        {depth}             (number)      file tree depth to display, `false`
-                                          for unlimited depth (default: 1)
-        {select_buffer}     (boolean)     select current buffer if possible;
-                                          may imply `hidden=true` (default:
-                                          false)
-        {hidden}            (boolean)     determines whether to show hidden
-                                          files or not (default: false)
-        {respect_gitignore} (boolean)     induces slow-down w/ plenary finder
-                                          (default: false, true if `fd`
-                                          available)
-        {browse_files}      (function)    custom override for the file browser
-                                          (default: |fb_finders.browse_files|)
-        {browse_folders}    (function)    custom override for the folder
-                                          browser (default:
-                                          |fb_finders.browse_folders|)
-        {hide_parent_dir}   (boolean)     hide `../` in the file browser
-                                          (default: false)
-        {quiet}             (boolean)     surpress any notification from
-                                          file_brower actions (default: false)
-        {dir_icon}          (string)      change the icon for a directory
-                                          (default: )
-        {dir_icon_hl}       (string)      change the highlight group of dir
-                                          icon (default: "Default")
-        {display_stat}      (bool|table)  ordered stat; see above notes,
-                                          (default: `{ date = true, size =
-                                          true }`)
+        {path}              (string)         dir to browse files from from,
+                                             `vim.fn.expanded` automatically
+                                             (default: vim.loop.cwd())
+        {cwd}               (string)         dir to browse folders from,
+                                             `vim.fn.expanded` automatically
+                                             (default: vim.loop.cwd())
+        {cwd_to_path}       (boolean)        whether folder browser is
+                                             launched from `path` rather than
+                                             `cwd` (default: false)
+        {grouped}           (boolean)        group initial sorting by
+                                             directories and then files; uses
+                                             plenary.scandir (default: false)
+        {files}             (boolean)        start in file (true) or folder
+                                             (false) browser (default: true)
+        {add_dirs}          (boolean)        whether the file browser shows
+                                             folders (default: true)
+        {depth}             (number)         file tree depth to display,
+                                             `false` for unlimited depth
+                                             (default: 1)
+        {select_buffer}     (boolean)        select current buffer if
+                                             possible; may imply `hidden=true`
+                                             (default: false)
+        {hidden}            (boolean)        determines whether to show hidden
+                                             files or not (default: false)
+        {respect_gitignore} (boolean)        induces slow-down w/ plenary
+                                             finder (default: false, true if
+                                             `fd` available)
+        {browse_files}      (function)       custom override for the file
+                                             browser (default:
+                                             |fb_finders.browse_files|)
+        {browse_folders}    (function)       custom override for the folder
+                                             browser (default:
+                                             |fb_finders.browse_folders|)
+        {hide_parent_dir}   (boolean)        hide `../` in the file browser
+                                             (default: false)
+        {quiet}             (boolean)        surpress any notification from
+                                             file_brower actions (default:
+                                             false)
+        {dir_icon}          (string)         change the icon for a directory
+                                             (default: )
+        {dir_icon_hl}       (string)         change the highlight group of dir
+                                             icon (default: "Default")
+        {display_stat}      (boolean|table)  ordered stat; see above notes,
+                                             (default: `{ date = true, size =
+                                             true }`)
+        {hijack_netrw}      (boolean)        use telescope file browser when
+                                             opening directory paths; must be
+                                             set on `setup` (default: false)
 
 
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -68,7 +68,8 @@ local fb_picker = {}
 ---@field quiet boolean: surpress any notification from file_brower actions (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
----@field display_stat bool|table: ordered stat; see above notes, (default: `{ date = true, size = true }`)
+---@field display_stat boolean|table: ordered stat; see above notes, (default: `{ date = true, size = true }`)
+---@field hijack_netrw boolean: use telescope file browser when opening directory paths; must be set on `setup` (default: false)
 fb_picker.file_browser = function(opts)
   opts = opts or {}
 


### PR DESCRIPTION
There's been several requests of launching `file_browser` on `VimEnter` over netwr. I was initially skeptical of implementing this but considering this plugin is somewhat an alternative to file browsers/explorers/trees like [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua) and seeing as how they've implemented it, I thought why not. At least as an opt-in feature.

I can add some notes in the docs/readme but I wanted to get some thoughts on the idea as well as the potentially over-simplistic implementation of it. 