### PR TITLE
fix: preserve custom titles

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -149,6 +149,8 @@ fb_finders.finder = function(opts)
     close = function(self)
       self._finder = nil
     end,
+    custom_prompt_title = opts.custom_prompt_title,
+    custom_results_title = opts.custom_results_title,
   }, {
     __call = function(self, ...)
       -- (re-)initialize finder on first start or refresh due to action

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -149,8 +149,8 @@ fb_finders.finder = function(opts)
     close = function(self)
       self._finder = nil
     end,
-    custom_prompt_title = opts.custom_prompt_title,
-    custom_results_title = opts.custom_results_title,
+    prompt_title = opts.custom_prompt_title,
+    results_title = opts.custom_results_title,
   }, {
     __call = function(self, ...)
       -- (re-)initialize finder on first start or refresh due to action

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -83,6 +83,8 @@ fb_picker.file_browser = function(opts)
   opts.files = vim.F.if_nil(opts.files, true)
   opts.hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
+  opts.custom_prompt_title = opts.prompt_title ~= nil
+  opts.custom_results_title = opts.results_title ~= nil
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -108,11 +108,11 @@ end
 -- redraws prompt and results border contingent on picker status
 fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
-  if current_picker.prompt_border and not finder.custom_prompt_title then
+  if current_picker.prompt_border and not finder.prompt_title then
     local new_title = finder.files and "File Browser" or "Folder Browser"
     current_picker.prompt_border:change_title(new_title)
   end
-  if current_picker.results_border and not finder.custom_results_title then
+  if current_picker.results_border and not finder.results_title then
     local new_title
     if finder.files or finder.cwd_to_path then
       new_title = Path:new(finder.path):make_relative(vim.loop.cwd())

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -108,11 +108,11 @@ end
 -- redraws prompt and results border contingent on picker status
 fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
-  if current_picker.prompt_border then
+  if current_picker.prompt_border and not finder.custom_prompt_title then
     local new_title = finder.files and "File Browser" or "Folder Browser"
     current_picker.prompt_border:change_title(new_title)
   end
-  if current_picker.results_border then
+  if current_picker.results_border and not finder.custom_results_title then
     local new_title
     if finder.files or finder.cwd_to_path then
       new_title = Path:new(finder.path):make_relative(vim.loop.cwd())


### PR DESCRIPTION
Telescope allows the user to specify "prompt_title" and "results_title". I was making a theme and used those values to have custom titles which works fine for the default finders, but not for this one because the titles change upon changing directory. This fix prevents "fb_utils.redraw_border_title" from overwriting the titles if they are custom.