### PR TITLE
feat: notify and vim.ui harmonization

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -36,9 +36,7 @@ jobs:
         run: |
           # We have to build the parser every single time to keep up with parser changes
           cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
-          mkdir -p build parser
-          cc -o ./build/parser.so -I./src src/parser.c src/scanner.cc -shared -Os -lstdc++ -fPIC
-          ln -s ../build/parser.so parser/lua.so
+          make dist
           cd -
 
       - name: Generating docs

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -129,6 +129,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                           |fb_finders.browse_folders|)
         {hide_parent_dir}   (boolean)     hide `../` in the file browser
                                           (default: false)
+        {quiet}             (boolean)     surpress any notification from
+                                          file_brower actions (default: false)
         {dir_icon}          (string)      change the icon for a directory
                                           (default: )
         {dir_icon_hl}       (string)      change the highlight group of dir

--- a/lua/telescope/_extensions/file_browser.lua
+++ b/lua/telescope/_extensions/file_browser.lua
@@ -54,108 +54,23 @@ end
 local fb_actions = require "telescope._extensions.file_browser.actions"
 local fb_finders = require "telescope._extensions.file_browser.finders"
 local fb_picker = require "telescope._extensions.file_browser.picker"
-local fb_utils = require "telescope._extensions.file_browser.utils"
-
-local action_state = require "telescope.actions.state"
-local action_set = require "telescope.actions.set"
-local state = require "telescope.state"
-local Path = require "plenary.path"
-
-local pconf = {
-  mappings = {
-    ["i"] = {
-      ["<A-c>"] = fb_actions.create,
-      ["<A-r>"] = fb_actions.rename,
-      ["<A-m>"] = fb_actions.move,
-      ["<A-y>"] = fb_actions.copy,
-      ["<A-d>"] = fb_actions.remove,
-      ["<C-o>"] = fb_actions.open,
-      ["<C-g>"] = fb_actions.goto_parent_dir,
-      ["<C-e>"] = fb_actions.goto_home_dir,
-      ["<C-w>"] = fb_actions.goto_cwd,
-      ["<C-t>"] = fb_actions.change_cwd,
-      ["<C-f>"] = fb_actions.toggle_browser,
-      ["<C-h>"] = fb_actions.toggle_hidden,
-      ["<C-s>"] = fb_actions.toggle_all,
-    },
-    ["n"] = {
-      ["c"] = fb_actions.create,
-      ["r"] = fb_actions.rename,
-      ["m"] = fb_actions.move,
-      ["y"] = fb_actions.copy,
-      ["d"] = fb_actions.remove,
-      ["o"] = fb_actions.open,
-      ["g"] = fb_actions.goto_parent_dir,
-      ["e"] = fb_actions.goto_home_dir,
-      ["w"] = fb_actions.goto_cwd,
-      ["t"] = fb_actions.change_cwd,
-      ["f"] = fb_actions.toggle_browser,
-      ["h"] = fb_actions.toggle_hidden,
-      ["s"] = fb_actions.toggle_all,
-    },
-  },
-  attach_mappings = function(prompt_bufnr, _)
-    action_set.select:replace_if(function()
-      -- test whether selected entry is directory
-      local entry = action_state.get_selected_entry()
-      local current_picker = action_state.get_current_picker(prompt_bufnr)
-      local finder = current_picker.finder
-      return (finder.files and entry == nil) or (entry and entry.Path:is_dir())
-    end, function()
-      local entry = action_state.get_selected_entry()
-      if entry and entry.Path:is_dir() then
-        local path = vim.loop.fs_realpath(entry.path)
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local finder = current_picker.finder
-        finder.files = true
-        finder.path = path
-        fb_utils.redraw_border_title(current_picker)
-        current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
-      else
-        -- Create file from prompt
-        -- TODO notification about created file once PR lands
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local finder = current_picker.finder
-        if finder.files then
-          local file = Path:new { finder.path, current_picker:_get_prompt() }
-          if not fb_utils.is_dir(file.filename) then
-            file:touch { parents = true }
-          else
-            Path:new(file.filename:sub(1, -2)):mkdir { parents = true }
-          end
-          local path = file:absolute()
-          -- pretend new file path is entry
-          state.set_global_key("selected_entry", { path = path, filename = path, Path = file })
-          -- select as if were proper entry to support eg changing into created folder
-          action_set.select(prompt_bufnr, "default")
-        end
-      end
-    end)
-    return true
-  end,
-}
-
-local fb_setup = function(opts)
-  -- TODO maybe merge other keys as well from telescope.config
-  pconf.mappings = vim.tbl_deep_extend("force", pconf.mappings, require("telescope.config").values.mappings)
-  pconf = vim.tbl_deep_extend("force", pconf, opts)
-end
+local fb_config = require "telescope._extensions.file_browser.config"
 
 local file_browser = function(opts)
   opts = opts or {}
   local defaults = (function()
-    if pconf.theme then
-      return require("telescope.themes")["get_" .. pconf.theme](pconf)
+    if fb_config.values.theme then
+      return require("telescope.themes")["get_" .. fb_config.values.theme](fb_config)
     end
-    return vim.deepcopy(pconf)
+    return vim.deepcopy(fb_config.values)
   end)()
 
-  if pconf.mappings then
+  if fb_config.values.mappings then
     defaults.attach_mappings = function(prompt_bufnr, map)
-      if pconf.attach_mappings then
-        pconf.attach_mappings(prompt_bufnr, map)
+      if fb_config.values.attach_mappings then
+        fb_config.values.attach_mappings(prompt_bufnr, map)
       end
-      for mode, tbl in pairs(pconf.mappings) do
+      for mode, tbl in pairs(fb_config.values.mappings) do
         for key, action in pairs(tbl) do
           map(mode, key, action)
         end
@@ -176,7 +91,7 @@ local file_browser = function(opts)
 end
 
 return telescope.register_extension {
-  setup = fb_setup,
+  setup = fb_config.setup,
   exports = {
     file_browser = file_browser,
     actions = fb_actions,

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -280,11 +280,11 @@ fb_actions.move = function(prompt_bufnr)
 
   local message = ""
   if not vim.tbl_isempty(moved) then
-    message = message .. "Moved selections: " .. table.concat(moved, ", ")
+    message = message .. "Moved: " .. table.concat(moved, ", ")
   end
   if not vim.tbl_isempty(skipped) then
     message = message ~= "" and (message .. "\n") or message
-    message = message .. "Skipping existing entries: " .. table.concat(skipped, ", ")
+    message = message .. "Skipping existing: " .. table.concat(skipped, ", ")
   end
   fb_utils.notify("actions.move", { msg = message, level = "INFO", quiet = finder.quiet })
 
@@ -349,7 +349,7 @@ fb_actions.copy = function(prompt_bufnr)
       exists = false
       vim.ui.input({
         prompt = string.format(
-          "Target exists, enter new name or <CR/ESC> to overwrite (merge) / pass file (dir):\n",
+          "Please enter a new name, <CR> to overwrite (merge), or <ESC> to skip file (folder):\n",
           name
         ),
         default = destination:absolute(),
@@ -368,7 +368,7 @@ fb_actions.copy = function(prompt_bufnr)
       end)
     else
       if not vim.tbl_isempty(copied) then
-        local message = "These entries were copied: " .. table.concat(copied, ", ")
+        local message = "Copied: " .. table.concat(copied, ", ")
         fb_utils.notify("actions.copy", { msg = message, level = "INFO", quiet = finder.quiet })
       end
     end
@@ -432,7 +432,7 @@ fb_actions.remove = function(prompt_bufnr)
       end
       fb_utils.notify(
         "actions.remove",
-        { msg = "Removed selections: " .. table.concat(removed, ", "), level = "INFO", quiet = quiet }
+        { msg = "Removed: " .. table.concat(removed, ", "), level = "INFO", quiet = quiet }
       )
       current_picker:refresh(current_picker.finder)
     else

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -1,0 +1,98 @@
+local fb_actions = require "telescope._extensions.file_browser.actions"
+local fb_utils = require "telescope._extensions.file_browser.utils"
+
+local action_state = require "telescope.actions.state"
+local action_set = require "telescope.actions.set"
+local state = require "telescope.state"
+local Path = require "plenary.path"
+
+local config = {}
+
+_TelescopeFileBrowserConfig = {
+  quiet = false,
+  mappings = {
+    ["i"] = {
+      ["<A-c>"] = fb_actions.create,
+      ["<A-r>"] = fb_actions.rename,
+      ["<A-m>"] = fb_actions.move,
+      ["<A-y>"] = fb_actions.copy,
+      ["<A-d>"] = fb_actions.remove,
+      ["<C-o>"] = fb_actions.open,
+      ["<C-g>"] = fb_actions.goto_parent_dir,
+      ["<C-e>"] = fb_actions.goto_home_dir,
+      ["<C-w>"] = fb_actions.goto_cwd,
+      ["<C-t>"] = fb_actions.change_cwd,
+      ["<C-f>"] = fb_actions.toggle_browser,
+      ["<C-h>"] = fb_actions.toggle_hidden,
+      ["<C-s>"] = fb_actions.toggle_all,
+    },
+    ["n"] = {
+      ["c"] = fb_actions.create,
+      ["r"] = fb_actions.rename,
+      ["m"] = fb_actions.move,
+      ["y"] = fb_actions.copy,
+      ["d"] = fb_actions.remove,
+      ["o"] = fb_actions.open,
+      ["g"] = fb_actions.goto_parent_dir,
+      ["e"] = fb_actions.goto_home_dir,
+      ["w"] = fb_actions.goto_cwd,
+      ["t"] = fb_actions.change_cwd,
+      ["f"] = fb_actions.toggle_browser,
+      ["h"] = fb_actions.toggle_hidden,
+      ["s"] = fb_actions.toggle_all,
+    },
+  },
+  attach_mappings = function(prompt_bufnr, _)
+    action_set.select:replace_if(function()
+      -- test whether selected entry is directory
+      local entry = action_state.get_selected_entry()
+      local current_picker = action_state.get_current_picker(prompt_bufnr)
+      local finder = current_picker.finder
+      return (finder.files and entry == nil) or (entry and entry.Path:is_dir())
+    end, function()
+      local entry = action_state.get_selected_entry()
+      if entry and entry.Path:is_dir() then
+        local path = vim.loop.fs_realpath(entry.path)
+        local current_picker = action_state.get_current_picker(prompt_bufnr)
+        local finder = current_picker.finder
+        finder.files = true
+        finder.path = path
+        fb_utils.redraw_border_title(current_picker)
+        current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+      else
+        -- Create file from prompt
+        -- TODO notification about created file once PR lands
+        local current_picker = action_state.get_current_picker(prompt_bufnr)
+        local finder = current_picker.finder
+        if finder.files then
+          local file = Path:new { finder.path, current_picker:_get_prompt() }
+          if not fb_utils.is_dir(file.filename) then
+            file:touch { parents = true }
+          else
+            Path:new(file.filename:sub(1, -2)):mkdir { parents = true }
+          end
+          local path = file:absolute()
+          -- pretend new file path is entry
+          state.set_global_key("selected_entry", { path = path, filename = path, Path = file })
+          -- select as if were proper entry to support eg changing into created folder
+          action_set.select(prompt_bufnr, "default")
+        end
+      end
+    end)
+    return true
+  end,
+} or _TelescopeFileBrowserConfig
+
+config.values = _TelescopeFileBrowserConfig
+
+config.setup = function(opts)
+  -- TODO maybe merge other keys as well from telescope.config
+  config.values.mappings = vim.tbl_deep_extend(
+    "force",
+    config.values.mappings,
+    require("telescope.config").values.mappings
+  )
+  config.values = vim.tbl_deep_extend("force", config.values, opts)
+end
+
+return config

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -137,6 +137,7 @@ fb_finders.finder = function(opts)
     respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode
     grouped = vim.F.if_nil(opts.grouped, false),
+    quiet = vim.F.if_nil(opts.quiet, false),
     select_buffer = vim.F.if_nil(opts.select_buffer, false),
     hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false),
     -- ensure we forward make_entry opts adequately

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -47,22 +47,22 @@ local DATE = {
 local stat_enum = { size = SIZE, date = DATE }
 
 local get_fb_prompt = function()
-  local prompt_buf = vim.tbl_filter(function(b)
+  local prompt_bufnr = vim.tbl_filter(function(b)
     return vim.bo[b].filetype == "TelescopePrompt"
   end, vim.api.nvim_list_bufs())
   -- vim.ui.{input, select} might be telescope pickers
-  if #prompt_buf > 1 then
-    for _, buf in ipairs(prompt_buf) do
-      local current_picker = action_state.get_current_picker(prompt_buf)
+  if #prompt_bufnr > 1 then
+    for _, buf in ipairs(prompt_bufnr) do
+      local current_picker = action_state.get_current_picker(prompt_bufnr)
       if current_picker.finder._browse_files then
-        prompt_buf = buf
+        prompt_bufnr = buf
         break
       end
     end
   else
-    prompt_buf = prompt_buf[1]
+    prompt_bufnr = prompt_bufnr[1]
   end
-  return prompt_buf
+  return prompt_bufnr
 end
 
 -- General:
@@ -76,8 +76,8 @@ end
 --   - Path: cache plenary.Path object of entry
 --   - stat: lazily cached vim.loop.fs_stat of entry
 local make_entry = function(opts)
-  local prompt_buf = get_fb_prompt()
-  local status = state.get_status(prompt_buf)
+  local prompt_bufnr = get_fb_prompt()
+  local status = state.get_status(prompt_bufnr)
   -- Compute total file width of results buffer:
   -- The results buffer typically splits like this with this notation {item, width}
   -- {devicon, 1} { name, variable }, { stat, stat_width, typically right_justify }
@@ -160,6 +160,7 @@ local make_entry = function(opts)
     local displayer = entry_display.create {
       separator = " ",
       items = widths,
+      prompt_bufnr = prompt_bufnr,
     }
     return displayer(display_array)
   end

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -17,6 +17,7 @@ local pickers = require "telescope.pickers"
 local conf = require("telescope.config").values
 
 local fb_finder = require "telescope._extensions.file_browser.finders"
+local fb_utils = require "telescope._extensions.file_browser.utils"
 
 local Path = require "plenary.path"
 local os_sep = Path.path.sep
@@ -25,18 +26,6 @@ local os_sep = Path.path.sep
 local fb_picker = {}
 
 -- try to get the index of entry of current buffer
-local get_selection_index = function(buf_name, path, results)
-  local current_dir = Path:new(buf_name):parent():absolute()
-
-  if path == current_dir then
-    for i, path_entry in ipairs(results) do
-      if path_entry.value == buf_name then
-        return i
-      end
-    end
-  end
-  return vim.F.if_nil(opts.default_selection_index, 1)
-end
 
 --- List, create, delete, rename, or move files and folders of your cwd.<br>
 --- Notes
@@ -76,6 +65,7 @@ end
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
+---@field quiet boolean: surpress any notification from file_brower actions (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
 ---@field display_stat bool|table: ordered stat; see above notes, (default: `{ date = true, size = true }`)
@@ -88,6 +78,7 @@ fb_picker.file_browser = function(opts)
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or cwd
   opts.path = opts.path and vim.fn.expand(opts.path) or opts.cwd
   opts.files = vim.F.if_nil(opts.files, true)
+  opts.quiet = vim.F.if_nil(opts.quiet, false)
   opts.hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
   opts.display_stat = vim.F.if_nil(opts.display_stat, { date = true, size = true })
@@ -97,24 +88,25 @@ fb_picker.file_browser = function(opts)
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
   opts.hidden = (select_buffer and vim.fn.expand("%:p:t"):sub(1, 1) == ".") and true or opts.hidden
+  opts.finder = fb_finder.finder(opts)
   -- find index of current buffer in the results
   if select_buffer then
     local buf_name = vim.api.nvim_buf_get_name(0)
-    opts._completion_callbacks = vim.F.if_nil(opts._completion_callbacks, {})
-    table.insert(opts._completion_callbacks, function(current_picker)
-      local finder = current_picker.finder
-      local selection_index = get_selection_index(buf_name, finder.path, finder.results)
-      if selection_index ~= 1 then
-        current_picker:set_selection(current_picker:get_row(selection_index))
-      end
-      table.remove(current_picker._completion_callbacks)
-    end)
+    fb_utils.selection_callback(opts, buf_name)
+    -- opts._completion_callbacks = vim.F.if_nil(opts._completion_callbacks, {})
+    -- table.insert(opts._completion_callbacks, function(current_picker)
+    --   local finder = current_picker.finder
+    --   local selection_index = fb_utils._get_selection_index(buf_name, finder.path, finder.results)
+    --   if selection_index ~= 1 then
+    --     current_picker:set_selection(current_picker:get_row(selection_index))
+    --   end
+    --   table.remove(current_picker._completion_callbacks)
+    -- end)
   end
 
   pickers.new(opts, {
     prompt_title = opts.files and "File Browser" or "Folder Browser",
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
-    finder = fb_finder.finder(opts),
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),
   }):find()


### PR DESCRIPTION
Continuation of #72

Closes #91 #87 

Changelog:
- Use `vim.ui.input` and `vim.notify` everywhere
- Smoothly pretty much all `hit-enter prompt`s by `redraw` on `vim.ui.input` with default `vim.notify` and casting all messages on a single line (probably not amazing if tons of single files/folders are created/deleted/etc. but can deal with it later)
- Introduce `quiet` option to suppress all outputs 
- Refactoring a proper config module
- Disallow removing parent folder (`file_browser`) and current folder (`folder_browser`) (yes, I've done something like that accidentally in my testing.. all my lua repos had to be restored via timeshift haha)
 
Since it is a very large PR, I apologize in before for any regression caused :) In my testing I couldn't find any, I've been on this branch some time and retested important actions repeatedly, but I'm sure a larger user base will find things.