### PR TITLE
fix: pass defaults thru theme

### DIFF
--- a/lua/telescope/_extensions/file_browser.lua
+++ b/lua/telescope/_extensions/file_browser.lua
@@ -60,7 +60,7 @@ local file_browser = function(opts)
   opts = opts or {}
   local defaults = (function()
     if fb_config.values.theme then
-      return require("telescope.themes")["get_" .. fb_config.values.theme](fb_config)
+      return require("telescope.themes")["get_" .. fb_config.values.theme](fb_config.values)
     end
     return vim.deepcopy(fb_config.values)
   end)()


### PR DESCRIPTION
Currently, using the non-default picker theme won't pass your defaults through correctly forcing the plugin defaults to be used.