### PR TITLE
fix(entry_maker): regression with trailng os separator in dirs

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -520,7 +520,7 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
   bypass = vim.F.if_nil(bypass, true)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
-  local parent_dir = Path:new(finder.path):parent()
+  local parent_dir = Path:new(finder.path):parent():absolute()
 
   if not bypass then
     if vim.loop.cwd() == finder.path then
@@ -532,7 +532,7 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
     end
   end
 
-  finder.path = parent_dir .. os_sep
+  finder.path = parent_dir
   fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
@@ -542,7 +542,7 @@ end
 fb_actions.goto_cwd = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
-  finder.path = vim.loop.cwd() .. os_sep
+  finder.path = vim.loop.cwd()
 
   fb_utils.redraw_border_title(current_picker)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -116,13 +116,12 @@ local make_entry = function(opts)
   local parent_dir = Path:new(opts.cwd):parent():absolute()
   local mt = {}
   mt.cwd = opts.cwd
-  -- +1 to start at first file char
-  local cwd_substr = #mt.cwd + #os_sep + 1
+  -- +1 to start at first file char; cwd may or may not end in os_sep
+  local cwd_substr = #mt.cwd + 1
+  cwd_substr = mt.cwd:sub(-1, -1) ~= os_sep and cwd_substr + #os_sep or cwd_substr
 
   -- TODO(fdschmidt93): handle VimResized with due to variable width
   mt.display = function(entry)
-    -- mt.cwd can change due to caching and traversal
-    opts.cwd = mt.cwd
     -- TODO make more configurable
     local widths = {}
     local display_array = {}


### PR DESCRIPTION
Unlike `fd` or `plenary`, `fb_actions.goto_{...}` appended an os separator the quick ordinal derivation did not account for.

Now, that's both unified -- the actions don't append a separator and the entry maker accounts for maybe having a separator appended to the cwd.

Closes #138 