### PR TITLE
hijack netrw - wipe the buffer matching the directory name

### DIFF
--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -87,6 +87,9 @@ local hijack_netrw = function()
           netrw_bufname = bufname
         end
 
+        -- ensure no buffers remain with the directory name
+        vim.api.nvim_buf_set_option(0, "bufhidden", "wipe")
+
         require("telescope").extensions.file_browser.file_browser {
           cwd = vim.fn.expand "%:p:h",
         }


### PR DESCRIPTION
Prevents extra buffers being left that have the name of an opened directory.

@jamestrew 