### PR TITLE
fix: allow netrw to handle url openings when `hijack_netrw = true`

### DIFF
--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -82,9 +82,6 @@ _TelescopeFileBrowserConfig = {
 config.values = _TelescopeFileBrowserConfig
 
 local hijack_netrw = function()
-  vim.g.loaded_netrw = 1
-  vim.g.loaded_netrwPlugin = 1
-
   local netrw_bufname
   vim.api.nvim_create_augroup("FileExplorer", { clear = true })
   vim.api.nvim_create_autocmd("BufEnter", {

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -205,10 +205,8 @@ local make_entry = function(opts)
   return function(absolute_path)
     local e = setmetatable({
       absolute_path,
-      ordinal = (absolute_path == opts.cwd and ".") or (absolute_path == parent_dir and ".." or absolute_path:sub(
-        cwd_substr,
-        -1
-      )),
+      ordinal = (absolute_path == opts.cwd and ".")
+        or (absolute_path == parent_dir and ".." or absolute_path:sub(cwd_substr, -1)),
     }, mt)
 
     -- telescope-file-browser has to cache the entries to resolve multi-selections


### PR DESCRIPTION
netrw handles opening of urls via an autcmd when doing `nvim <url>` or `:e <url>`.

Disabling netrw entirely when `hijack_netrw = true` had the unintended side effect of breaking the above mentioned feature so I'm removing the disabling of netrw.

Closes #149 