### PR TITLE
feat: prompt title accepts string or function

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -1,5 +1,5 @@
 ================================================================================
-NVIM                                               *telescope-file-browser.nvim*
+                                                   *telescope-file-browser.nvim*
 
 `telescope-file-browser.nvim` is an extension for telescope.nvim. It helps you
 efficiently create, delete, rename, or move files powered by navigation from
@@ -47,7 +47,7 @@ https://github.com/nvim-telescope/telescope-file-browser.nvim
 
 
 ================================================================================
-PICKER                                           *telescope-file-browser.picker*
+                                                 *telescope-file-browser.picker*
 
 You can use the file browser as follows
 >
@@ -96,7 +96,7 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}              (string)         dir to browse files from,
+        {path}              (string)         dir to browse files from from,
                                              `vim.fn.expanded` automatically
                                              (default: vim.loop.cwd())
         {cwd}               (string)         dir to browse folders from,
@@ -131,9 +131,6 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                              |fb_finders.browse_folders|)
         {hide_parent_dir}   (boolean)        hide `../` in the file browser
                                              (default: false)
-        {collapse_dirs}     (boolean)        skip dirs w/ only single
-                                             (possibly hidden) sub-dir in
-                                             file_browser (default: false)
         {quiet}             (boolean)        surpress any notification from
                                              file_brower actions (default:
                                              false)
@@ -147,12 +144,12 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name as prompt
-                                             title (default: false)
+        {follow}            (boolean)        show the directory name, relative
+                                             to `cwd`, as prompt title (default: false)
 
 
 ================================================================================
-ACTIONS                                         *telescope-file-browser.actions*
+                                                *telescope-file-browser.actions*
 
 The file browser actions are functions enable file system operations from
 within the file browser picker. In particular, the actions include creation,
@@ -366,7 +363,7 @@ fb_actions.sort_by_date()      *telescope-file-browser.actions.sort_by_date()*
 
 
 ================================================================================
-FINDERS                                         *telescope-file-browser.finders*
+                                                *telescope-file-browser.finders*
 
 The file browser finders power the picker with both a file and folder browser.
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -1,5 +1,5 @@
 ================================================================================
-                                                   *telescope-file-browser.nvim*
+NVIM                                               *telescope-file-browser.nvim*
 
 `telescope-file-browser.nvim` is an extension for telescope.nvim. It helps you
 efficiently create, delete, rename, or move files powered by navigation from
@@ -47,7 +47,7 @@ https://github.com/nvim-telescope/telescope-file-browser.nvim
 
 
 ================================================================================
-                                                 *telescope-file-browser.picker*
+PICKER                                           *telescope-file-browser.picker*
 
 You can use the file browser as follows
 >
@@ -96,7 +96,7 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}              (string)         dir to browse files from from,
+        {path}              (string)         dir to browse files from,
                                              `vim.fn.expanded` automatically
                                              (default: vim.loop.cwd())
         {cwd}               (string)         dir to browse folders from,
@@ -131,6 +131,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                              |fb_finders.browse_folders|)
         {hide_parent_dir}   (boolean)        hide `../` in the file browser
                                              (default: false)
+        {collapse_dirs}     (boolean)        skip dirs w/ only single
+                                             (possibly hidden) sub-dir in
+                                             file_browser (default: false)
         {quiet}             (boolean)        surpress any notification from
                                              file_brower actions (default:
                                              false)
@@ -144,12 +147,11 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name as prompt
-                                             title (default: false)
+
 
 
 ================================================================================
-                                                *telescope-file-browser.actions*
+ACTIONS                                         *telescope-file-browser.actions*
 
 The file browser actions are functions enable file system operations from
 within the file browser picker. In particular, the actions include creation,
@@ -363,7 +365,7 @@ fb_actions.sort_by_date()      *telescope-file-browser.actions.sort_by_date()*
 
 
 ================================================================================
-                                                *telescope-file-browser.finders*
+FINDERS                                         *telescope-file-browser.finders*
 
 The file browser finders power the picker with both a file and folder browser.
 
@@ -409,31 +411,34 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}              (string)   root dir to file_browse from (default:
-                                       vim.loop.cwd())
-        {cwd}               (string)   root dir (default: vim.loop.cwd())
-        {cwd_to_path}       (bool)     folder browser follows `path` of file
-                                       browser
-        {files}             (boolean)  start in file (true) or folder (false)
-                                       browser (default: true)
-        {grouped}           (boolean)  group initial sorting by directories
-                                       and then files; uses plenary.scandir
-                                       (default: false)
-        {depth}             (number)   file tree depth to display (default: 1)
-        {hidden}            (boolean)  determines whether to show hidden files
-                                       or not (default: false)
-        {respect_gitignore} (boolean)  induces slow-down w/ plenary finder
-                                       (default: false, true if `fd`
-                                       available)
-        {hide_parent_dir}   (boolean)  hide `../` in the file browser
-                                       (default: false)
-        {dir_icon}          (string)   change the icon for a directory
-                                       (default: )
-        {dir_icon_hl}       (string)   change the highlight group of dir icon
-                                       (default: "Default")
+        {path}              (string)           root dir to file_browse from (default:
+                                               vim.loop.cwd())
+        {cwd}               (string)           root dir (default: vim.loop.cwd())
+        {cwd_to_path}       (bool)             folder browser follows `path` of file
+                                               browser
+        {files}             (boolean)          start in file (true) or folder (false)
+                                               browser (default: true)
+        {grouped}           (boolean)          group initial sorting by directories
+                                               and then files; uses plenary.scandir
+                                               (default: false)
+        {depth}             (number)           file tree depth to display (default: 1)
+        {hidden}            (boolean)          determines whether to show hidden files
+                                               or not (default: false)
+        {respect_gitignore} (boolean)          induces slow-down w/ plenary finder
+                                               (default: false, true if `fd`
+                                               available)
+        {hide_parent_dir}   (boolean)          hide `../` in the file browser
+                                               (default: false)
+        {dir_icon}          (string)           change the icon for a directory
+                                               (default: )
+        {dir_icon_hl}       (string)           change the highlight group of dir icon
+                                               (default: "Default")
+        {prompt_title}      (string|function)  change the title of the prompt.
+                                               a function will receive the
+                                               finder as parameter
+                                               (default: function)
+                                              
 
-        {follow}            (boolean)  show the directory name, relative
-                                       to `cwd`, as prompt title (default: false)
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -147,8 +147,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name, relative
-                                             to `cwd`, as prompt title (default: false)
+        {follow}            (boolean)        show the directory name, as prompt
+                                             title (default: false)
 
 
 ================================================================================

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -144,7 +144,7 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name, as prompt
+        {follow}            (boolean)        show the directory name as prompt
                                              title (default: false)
 
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -147,7 +147,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-
+        {follow}            (boolean)        show the directory name, relative
+                                             to `cwd`, as prompt title (default: false)
 
 
 ================================================================================
@@ -434,6 +435,8 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
         {dir_icon_hl}       (string)   change the highlight group of dir icon
                                        (default: "Default")
 
+        {follow}            (boolean)  show the directory name, relative
+                                       to `cwd`, as prompt title (default: false)
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -147,7 +147,7 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name, as prompt
+        {follow}            (boolean)        show the directory name as prompt
                                              title (default: false)
 
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -144,8 +144,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)        use telescope file browser when
                                              opening directory paths; must be
                                              set on `setup` (default: false)
-        {follow}            (boolean)        show the directory name, relative
-                                             to `cwd`, as prompt title (default: false)
+        {follow}            (boolean)        show the directory name, as prompt
+                                             title (default: false)
 
 
 ================================================================================

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -123,7 +123,6 @@ end
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
----@field follow boolean: show the directory (relative to cwd) that is being listed as prompt_title (default: false) 
 fb_finders.finder = function(opts)
   opts = opts or {}
   -- cache entries such that multi selections are maintained across {file, folder}_browsers
@@ -154,7 +153,6 @@ fb_finders.finder = function(opts)
     end,
     prompt_title = opts.custom_prompt_title,
     results_title = opts.custom_results_title,
-    follow = opts.follow,
   }, {
     __call = function(self, ...)
       -- (re-)initialize finder on first start or refresh due to action

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -123,6 +123,7 @@ end
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
+---@field follow boolean: show the directory (relative to cwd) that is being listed as prompt_title (default: false) 
 fb_finders.finder = function(opts)
   opts = opts or {}
   -- cache entries such that multi selections are maintained across {file, folder}_browsers
@@ -153,6 +154,7 @@ fb_finders.finder = function(opts)
     end,
     prompt_title = opts.custom_prompt_title,
     results_title = opts.custom_results_title,
+    follow = opts.follow,
   }, {
     __call = function(self, ...)
       -- (re-)initialize finder on first start or refresh due to action

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -151,7 +151,8 @@ fb_finders.finder = function(opts)
     close = function(self)
       self._finder = nil
     end,
-    prompt_title = opts.custom_prompt_title,
+    prompt_title = opts.prompt_title,
+    prompt_title_fn = opts.prompt_title_fn,
     results_title = opts.custom_results_title,
   }, {
     __call = function(self, ...)

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -108,9 +108,13 @@ fb_picker.file_browser = function(opts)
     --   table.remove(current_picker._completion_callbacks)
     -- end)
   end
-  local cwd_path = Path:new(opts.cwd)
+  local prompt_title = opts.files and "File Browser" or "Folder Browser"
+  if opts.follow then
+    local parent = Path:new(opts.cwd):parent().filename
+    prompt_title = Path:new(opts.path):make_relative(parent)
+  end
   pickers.new(opts, {
-    prompt_title = (opts.follow and cwd_path:make_relative(cwd_path:parent().filename)) or (opts.files and "File Browser") or "Folder Browser",
+    prompt_title = prompt_title,
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -52,7 +52,7 @@ local fb_picker = {}
 ---   - See make_entry.lua for an example on how to further customize
 ---
 ---@param opts table: options to pass to the picker
----@field path string: dir to browse files from from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
+---@field path string: dir to browse files from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd string: dir to browse folders from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd_to_path boolean: whether folder browser is launched from `path` rather than `cwd` (default: false)
 ---@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -133,7 +133,8 @@ fb_picker.file_browser = function(opts)
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),
-  }):find()
+  })
+  :find()
 end
 
 return fb_picker.file_browser

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -108,9 +108,9 @@ fb_picker.file_browser = function(opts)
     --   table.remove(current_picker._completion_callbacks)
     -- end)
   end
-
+  local cwd_path = Path:new(opts.cwd)
   pickers.new(opts, {
-    prompt_title = (opts.follow and opt.custom_prompt_title) or (opts.files and "File Browser") or "Folder Browser",
+    prompt_title = (opts.follow and cwd_path:make_relative(cwd_path:parent().filename)) or (opts.files and "File Browser") or "Folder Browser",
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -105,6 +105,7 @@ fb_picker.file_browser = function(opts)
   end
 
   function prompt_title_fn(finder)
+    local Path = require("plenary.path")
     local parent = Path:new(finder.cwd):parent().filename
     local new_title = Path:new(finder.path):make_relative(parent)
     if parent == finder.path then

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -52,7 +52,7 @@ local fb_picker = {}
 ---   - See make_entry.lua for an example on how to further customize
 ---
 ---@param opts table: options to pass to the picker
----@field path string: dir to browse files from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
+---@field path string: dir to browse files from from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd string: dir to browse folders from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd_to_path boolean: whether folder browser is launched from `path` rather than `cwd` (default: false)
 ---@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)
@@ -65,7 +65,6 @@ local fb_picker = {}
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
----@field collapse_dirs boolean: skip dirs w/ only single (possibly hidden) sub-dir in file_browser (default: false)
 ---@field quiet boolean: surpress any notification from file_brower actions (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
@@ -86,6 +85,10 @@ fb_picker.file_browser = function(opts)
   opts.display_stat = vim.F.if_nil(opts.display_stat, { date = true, size = true })
   opts.custom_prompt_title = opts.prompt_title ~= nil
   opts.custom_results_title = opts.results_title ~= nil
+  opts.follow = vim.F.if_nil(opts.follow, false)
+  if opts.follow then
+    opts.custom_prompt_title = vim.fn.expand('%:p:h:t')
+  end
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
@@ -106,14 +109,12 @@ fb_picker.file_browser = function(opts)
     -- end)
   end
 
-  pickers
-    .new(opts, {
-      prompt_title = opts.files and "File Browser" or "Folder Browser",
-      results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
-      previewer = conf.file_previewer(opts),
-      sorter = conf.file_sorter(opts),
-    })
-    :find()
+  pickers.new(opts, {
+    prompt_title = (opts.follow and opt.custom_prompt_title) or (opts.files and "File Browser") or "Folder Browser",
+    results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
+    previewer = conf.file_previewer(opts),
+    sorter = conf.file_sorter(opts),
+  }):find()
 end
 
 return fb_picker.file_browser

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -108,13 +108,9 @@ fb_picker.file_browser = function(opts)
     --   table.remove(current_picker._completion_callbacks)
     -- end)
   end
-  local prompt_title = opts.files and "File Browser" or "Folder Browser"
-  if opts.follow then
-    local parent = Path:new(opts.cwd):parent().filename
-    prompt_title = Path:new(opts.path):make_relative(parent)
-  end
+
   pickers.new(opts, {
-    prompt_title = prompt_title,
+    prompt_title = (opts.follow and opt.custom_prompt_title) or (opts.files and "File Browser") or "Folder Browser",
     results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
     previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -9,8 +9,6 @@ local truncate = require("plenary.strings").truncate
 
 local fb_utils = {}
 
-local Path = require "plenary.path"
-
 fb_utils.is_dir = function(path)
   if Path.is_path(path) then
     return path:is_dir()
@@ -112,12 +110,11 @@ fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
   if current_picker.prompt_border then
     if finder.follow then
-      local parent = Path:new(finder.cwd):parent().filename
-      local new_title = Path:new(finder.path):make_relative(parent)
-      if parent == finder.path then
-        new_title = parent
+      local new_title = Path:new(finder.path):make_relative(finder.cwd)
+      if new_title == '.' then
+        -- show the folder name
+        new_title = vim.fn.expand('%:p:h:t')
       end
-
       current_picker.prompt_border:change_title(new_title)
     elseif not finder.prompt_title then
       local new_title = finder.files and "File Browser" or "Folder Browser"

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -108,7 +108,7 @@ end
 -- redraws prompt and results border contingent on picker status
 fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
-  if current_picker.prompt_border and type(finder.prompt_title_fn) == "function" then
+  if current_picker.prompt_border and finder.prompt_title_fn then
     current_picker.prompt_border:change_title(finder.prompt_title_fn(finder))
   end
   if current_picker.results_border and not finder.results_title then

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -108,9 +108,18 @@ end
 -- redraws prompt and results border contingent on picker status
 fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
-  if current_picker.prompt_border and not finder.prompt_title then
-    local new_title = finder.files and "File Browser" or "Folder Browser"
-    current_picker.prompt_border:change_title(new_title)
+  if current_picker.prompt_border then
+    if finder.follow then
+      local new_title = Path:new(finder.path):make_relative(finder.cwd)
+      if new_title == '.' then
+        -- show the folder name
+        new_title = vim.fn.expand('%:p:h:t')
+      end
+      current_picker.prompt_border:change_title(new_title)
+    elseif not finder.prompt_title then
+      local new_title = finder.files and "File Browser" or "Folder Browser"
+      current_picker.prompt_border:change_title(new_title)
+    end
   end
   if current_picker.results_border and not finder.results_title then
     local new_title

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -110,11 +110,12 @@ fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
   if current_picker.prompt_border then
     if finder.follow then
-      local new_title = Path:new(finder.path):make_relative(finder.cwd)
-      if new_title == '.' then
-        -- show the folder name
-        new_title = vim.fn.expand('%:p:h:t')
+      local parent = Path:new(finder.cwd):parent().filename
+      local new_title = Path:new(finder.path):make_relative(parent)
+      if parent == finder.path then
+        new_title = finder.path
       end
+
       current_picker.prompt_border:change_title(new_title)
     elseif not finder.prompt_title then
       local new_title = finder.files and "File Browser" or "Folder Browser"

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -9,6 +9,8 @@ local truncate = require("plenary.strings").truncate
 
 local fb_utils = {}
 
+local Path = require "plenary.path"
+
 fb_utils.is_dir = function(path)
   if Path.is_path(path) then
     return path:is_dir()
@@ -113,7 +115,7 @@ fb_utils.redraw_border_title = function(current_picker)
       local parent = Path:new(finder.cwd):parent().filename
       local new_title = Path:new(finder.path):make_relative(parent)
       if parent == finder.path then
-        new_title = finder.path
+        new_title = parent
       end
 
       current_picker.prompt_border:change_title(new_title)

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -110,19 +110,8 @@ end
 -- redraws prompt and results border contingent on picker status
 fb_utils.redraw_border_title = function(current_picker)
   local finder = current_picker.finder
-  if current_picker.prompt_border then
-    if finder.follow then
-      local parent = Path:new(finder.cwd):parent().filename
-      local new_title = Path:new(finder.path):make_relative(parent)
-      if parent == finder.path then
-        new_title = parent
-      end
-
-      current_picker.prompt_border:change_title(new_title)
-    elseif not finder.prompt_title then
-      local new_title = finder.files and "File Browser" or "Folder Browser"
-      current_picker.prompt_border:change_title(new_title)
-    end
+  if current_picker.prompt_border and type(finder.prompt_title_fn) == "function" then
+    current_picker.prompt_border:change_title(finder.prompt_title_fn(finder))
   end
   if current_picker.results_border and not finder.results_title then
     local new_title

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -9,8 +9,6 @@ local truncate = require("plenary.strings").truncate
 
 local fb_utils = {}
 
-local Path = require "plenary.path"
-
 fb_utils.is_dir = function(path)
   if Path.is_path(path) then
     return path:is_dir()


### PR DESCRIPTION
## Motivation
When I'm navigating in different folders I want to see the name of the current folder listed in the finder's prompt title.

## Implementation
Expose `prompt_title` option as function or string.
If a function is passed, it will be evaluated with `current finder` as parameter.
If a string is passed, its value is set to the finder.
If not defined, the default value is a function that will output a string with the current path relative to the `cwd` of the finder.

A `opts.prompt_title_fn` field is added to store the function. This is due to telescope/plenary expecting a string in the `prompt_title` option

## Preview
Command `Telescope file_browser previewer=false theme=dropdown follow=true path=%:p:h`
![image](https://user-images.githubusercontent.com/43855513/176667640-0a9d8b8f-fd8f-475f-8956-60175d81fd08.png)

[Kapture 2022-06-30 at 15.41.50.webm](https://user-images.githubusercontent.com/43855513/176692519-e0a88c10-415e-486d-a6f6-2f82ce9e4914.webm)
