### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Note: `path` corresponds to the folder the `file_browser` is currently in.
 | `<A-r>/r`       |rename                  |Rename multi-selected files/folders                                              |
 | `<A-m>/m`       |move                    |Move multi-selected files/folders to current `path`                              |
 | `<A-y>/y`       |copy                    |Copy (multi-)selected files/folders to current `path`                            |
-| `<A-d>/d`       |delete                  |Delete (multi-)selected files/folders                                            |
+| `<A-d>/d`       |remove                  |Delete (multi-)selected files/folders                                            |
 | `<C-o>/o`       |open                    |Open file/folder with default system application                                 |
 | `<C-g>/g`       |goto_parent_dir         |Go to parent directory                                                           |
 | `<C-e>/e`       |goto_home_dir           |Go to home directory                                                             |


### PR DESCRIPTION
For deletion, the correct `fb_actions` is `remove` and not `delete`.

This PR updates the README documentation to avoid confusion, but I can see a rename of the internal API to use `delete` instead.