### PR TITLE
feat(file_browser): collapse dirs

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -131,6 +131,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                              |fb_finders.browse_folders|)
         {hide_parent_dir}   (boolean)        hide `../` in the file browser
                                              (default: false)
+        {collapse_dirs}     (boolean)        skip dirs w/ only single
+                                             (possibly hidden) sub-dir in
+                                             file_browser (default: false)
         {quiet}             (boolean)        surpress any notification from
                                              file_brower actions (default:
                                              false)

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -642,11 +642,8 @@ local sort_by = function(prompt_bufnr, sorter_fn)
     table.insert(entries, e)
   end
   table.sort(entries, sorter_fn)
-  current_picker.manager = EntryManager:new(
-    current_picker.max_results,
-    current_picker.entry_adder,
-    current_picker.stats
-  )
+  current_picker.manager =
+    EntryManager:new(current_picker.max_results, current_picker.entry_adder, current_picker.stats)
   local index = 1
   for _, entry in ipairs(entries) do
     current_picker.manager:_append_container(current_picker, { entry, 0 }, true)

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -1,5 +1,7 @@
 local fb_actions = require "telescope._extensions.file_browser.actions"
 local fb_utils = require "telescope._extensions.file_browser.utils"
+local scan = require "plenary.scandir"
+local Path = require "plenary.path"
 
 local action_state = require "telescope.actions.state"
 local action_set = require "telescope.actions.set"
@@ -47,10 +49,27 @@ _TelescopeFileBrowserConfig = {
       local entry = action_state.get_selected_entry()
       return entry and entry.Path:is_dir()
     end, function()
-      local entry = action_state.get_selected_entry()
-      local path = vim.loop.fs_realpath(entry.path)
       local current_picker = action_state.get_current_picker(prompt_bufnr)
       local finder = current_picker.finder
+      local entry = action_state.get_selected_entry()
+      local path = vim.loop.fs_realpath(entry.path)
+
+      if finder.files and finder.collapse_dirs then
+        local upwards = path == Path:new(finder.path):parent():absolute()
+        while true do
+          local dirs = scan.scan_dir(path, { add_dirs = true, depth = 1, hidden = true })
+          if #dirs == 1 and vim.fn.isdirectory(dirs[1]) then
+            path = upwards and Path:new(path):parent():absolute() or dirs[1]
+            -- make sure it's upper bound (#dirs == 1 implicitly reflects lower bound)
+            if path == Path:new(path):parent():absolute() then
+              break
+            end
+          else
+            break
+          end
+        end
+      end
+
       finder.files = true
       finder.path = path
       fb_utils.redraw_border_title(current_picker)
@@ -101,11 +120,8 @@ end
 
 config.setup = function(opts)
   -- TODO maybe merge other keys as well from telescope.config
-  config.values.mappings = vim.tbl_deep_extend(
-    "force",
-    config.values.mappings,
-    require("telescope.config").values.mappings
-  )
+  config.values.mappings =
+    vim.tbl_deep_extend("force", config.values.mappings, require("telescope.config").values.mappings)
   config.values = vim.tbl_deep_extend("force", config.values, opts)
 
   if config.values.hijack_netrw then

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -141,6 +141,7 @@ fb_finders.finder = function(opts)
     quiet = vim.F.if_nil(opts.quiet, false),
     select_buffer = vim.F.if_nil(opts.select_buffer, false),
     hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false),
+    collapse_dirs = vim.F.if_nil(opts.collapse_dirs, false),
     -- ensure we forward make_entry opts adequately
     entry_maker = vim.F.if_nil(opts.entry_maker, function(local_opts)
       return fb_make_entry(vim.tbl_extend("force", opts, local_opts))

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -65,6 +65,7 @@ local fb_picker = {}
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
+---@field collapse_dirs boolean: skip dirs w/ only single (possibly hidden) sub-dir in file_browser (default: false)
 ---@field quiet boolean: surpress any notification from file_brower actions (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
@@ -105,12 +106,14 @@ fb_picker.file_browser = function(opts)
     -- end)
   end
 
-  pickers.new(opts, {
-    prompt_title = opts.files and "File Browser" or "Folder Browser",
-    results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
-    previewer = conf.file_previewer(opts),
-    sorter = conf.file_sorter(opts),
-  }):find()
+  pickers
+    .new(opts, {
+      prompt_title = opts.files and "File Browser" or "Folder Browser",
+      results_title = opts.files and Path:new(opts.path):make_relative(cwd) .. os_sep or "Results",
+      previewer = conf.file_previewer(opts),
+      sorter = conf.file_sorter(opts),
+    })
+    :find()
 end
 
 return fb_picker.file_browser


### PR DESCRIPTION
With { collapse_dirs = true }
going from (example from stow)
`dotfiles/`
to
`dotfiles/nvim/.config/nvim/`
only requires selecting nvim
in `file_browser` as intermediate
single-folder levels are skipped.
This also works in the reverse
direction.

Closes #158 

@cc paul-ohl

Could you please test this PR with your config? :) just making sure it doesn't result in unintended infinite loops for someone other than me :laughing: 