### PR TITLE
fix: sort actions handle entries with no stat

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -661,6 +661,7 @@ fb_actions.sort_by_size = function(prompt_bufnr)
   local finder = action_state.get_current_picker(prompt_bufnr).finder
   finder.__sort_size = not finder.__sort_size
   sort_by(prompt_bufnr, function(x, y)
+    if not x.stat or y.stat then return false end
     if x.stat.size > y.stat.size then
       return finder.__sort_size
     elseif x.stat.size < y.stat.size then
@@ -678,6 +679,7 @@ fb_actions.sort_by_date = function(prompt_bufnr)
   local finder = action_state.get_current_picker(prompt_bufnr).finder
   finder.__sort_date = not finder.__sort_date
   sort_by(prompt_bufnr, function(x, y)
+    if not x.stat or y.stat then return false end
     if x.stat.mtime.sec > y.stat.mtime.sec then
       return finder.__sort_date
     elseif x.stat.mtime.sec < y.stat.mtime.sec then

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -661,7 +661,12 @@ fb_actions.sort_by_size = function(prompt_bufnr)
   local finder = action_state.get_current_picker(prompt_bufnr).finder
   finder.__sort_size = not finder.__sort_size
   sort_by(prompt_bufnr, function(x, y)
-    if not x.stat or y.stat then return false end
+    if not x.stat then
+      return false
+    end
+    if not y.stat then
+      return true
+    end
     if x.stat.size > y.stat.size then
       return finder.__sort_size
     elseif x.stat.size < y.stat.size then
@@ -679,7 +684,12 @@ fb_actions.sort_by_date = function(prompt_bufnr)
   local finder = action_state.get_current_picker(prompt_bufnr).finder
   finder.__sort_date = not finder.__sort_date
   sort_by(prompt_bufnr, function(x, y)
-    if not x.stat or y.stat then return false end
+    if not x.stat then
+      return false
+    end
+    if not y.stat then
+      return true
+    end
     if x.stat.mtime.sec > y.stat.mtime.sec then
       return finder.__sort_date
     elseif x.stat.mtime.sec < y.stat.mtime.sec then


### PR DESCRIPTION
Currently, if there is at least 1 entry where `vim.loop.fs_stat` fails, all the other entries can't be sorted.
With this fix I can now sort entries as entries with `stat=false` are ignored in sorting.

To reproduce:
```bash
cd /tmp && mkdir deadsym & cd deadsym
ln -s /tmp/nonexistent/file file
nvim -c 'Telescope file_browser'
# execute sort_by_date() or sort_by_size() action and it errors without finishing sorting.
```

```
E5108: Error executing lua ....nvim/lua/telescope/_extensions/file_browser/actions.lua:666: attempt to index field 'stat' (a boolean val
ue)                                                                                                                                     
stack traceback:                                                                                                                        
        ....nvim/lua/telescope/_extensions/file_browser/actions.lua:666: in function <....nvim/lua/telescope/_extensions/file_browser/ac
tions.lua:665>                                                                                                                          
        [C]: in function 'sort'                                                                                                         
        ....nvim/lua/telescope/_extensions/file_browser/actions.lua:643: in function 'sort_by'                                          
        ....nvim/lua/telescope/_extensions/file_browser/actions.lua:665: in function 'run_replace_or_original'                          
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'                                          
        ...a/packer/start/telescope.nvim/lua/telescope/mappings.lua:338: in function 'execute_keymap'                                   
        [string ":lua"]:1: in main chunk
```