### PR TITLE
fix(file_bowser): correct path separators on mingw

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -32,7 +32,7 @@ fb_finders.browse_files = function(opts)
   local parent_path = Path:new(opts.path):parent():absolute()
   local needs_sync = opts.grouped or opts.select_buffer
   if has_fd and not needs_sync then
-    local args = { "-a" }
+    local args = { "-a", "--path-separator=" .. os_sep }
     if opts.hidden then
       table.insert(args, "-H")
     end


### PR DESCRIPTION
fd on Windows outputs file paths with forward slashes when run under mingw. This ensures that fd always outputs backslashes on Windows systems. This should have no impact on other OSes.

Fix: https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/167