### PR TITLE
Enable to change icon width

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -141,8 +141,6 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                              (default: )
         {dir_icon_hl}       (string)         change the highlight group of dir
                                              icon (default: "Default")
-        {icon_width}        (number)         change the width of icons
-                                             (default: 1)
         {display_stat}      (boolean|table)  ordered stat; see above notes,
                                              (default: `{ date = true, size =
                                              true }`)
@@ -435,8 +433,6 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
                                        (default: )
         {dir_icon_hl}       (string)   change the highlight group of dir icon
                                        (default: "Default")
-        {icon_width}        (number)   change the width of icons
-                                       (default: 1)
 
 
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -141,6 +141,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                              (default: )
         {dir_icon_hl}       (string)         change the highlight group of dir
                                              icon (default: "Default")
+        {icon_width}        (number)         change the width of icons
+                                             (default: 1)
         {display_stat}      (boolean|table)  ordered stat; see above notes,
                                              (default: `{ date = true, size =
                                              true }`)
@@ -433,6 +435,8 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
                                        (default: )
         {dir_icon_hl}       (string)   change the highlight group of dir icon
                                        (default: "Default")
+        {icon_width}        (number)   change the width of icons
+                                       (default: 1)
 
 
 

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -5,7 +5,7 @@ local action_state = require "telescope.actions.state"
 local state = require "telescope.state"
 local Path = require "plenary.path"
 local os_sep = Path.path.sep
-local truncate = require("plenary.strings").truncate
+local strings = require "plenary.strings"
 
 local SIZE_TYPES = { "", "K", "M", "G", "T", "P", "E", "Z" }
 local YEAR = os.date "%Y"
@@ -141,14 +141,13 @@ local make_entry = function(opts)
       else
         icon, icon_hl = utils.get_devicons(entry.value, opts.disable_devicons)
       end
-      -- TODO maybe alleviate hard-coding
-      table.insert(widths, { width = 1 })
+      table.insert(widths, { width = strings.strdisplaywidth(icon) })
       table.insert(display_array, { icon, icon_hl })
     end
     opts.file_width = vim.F.if_nil(opts.file_width, math.max(15, total_file_width))
     -- TODO maybe this can be dealth with more cleanly
     if #path_display > opts.file_width then
-      path_display = truncate(path_display, opts.file_width, nil, -1)
+      path_display = strings.truncate(path_display, opts.file_width, nil, -1)
     end
     table.insert(display_array, entry.stat and path_display or { path_display, "WarningMsg" })
     table.insert(widths, { width = opts.file_width })

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -141,7 +141,8 @@ local make_entry = function(opts)
       else
         icon, icon_hl = utils.get_devicons(entry.value, opts.disable_devicons)
       end
-      table.insert(widths, { width = opts.icon_width or 1 })
+      -- TODO maybe alleviate hard-coding
+      table.insert(widths, { width = 1 })
       table.insert(display_array, { icon, icon_hl })
     end
     opts.file_width = vim.F.if_nil(opts.file_width, math.max(15, total_file_width))

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -141,8 +141,7 @@ local make_entry = function(opts)
       else
         icon, icon_hl = utils.get_devicons(entry.value, opts.disable_devicons)
       end
-      -- TODO maybe alleviate hard-coding
-      table.insert(widths, { width = 1 })
+      table.insert(widths, { width = opts.icon_width or 1 })
       table.insert(display_array, { icon, icon_hl })
     end
     opts.file_width = vim.F.if_nil(opts.file_width, math.max(15, total_file_width))


### PR DESCRIPTION
Neovim now has `setcellwidths()` ([doc][]) and we can set arbitrary codepoint to `1` or `2` widths despite of the `'ambiwidth'` setting.

[doc]: https://neovim.io/doc/user/builtin.html#setcellwidths()

I set devicon's glyphs can have `2` widths and found all icons become `…` characters. This patch enables to change this for such cases.

| before | after |
|--|--|
| <img width="353" alt="スクリーンショット 0004-08-18 14 50 06" src="https://user-images.githubusercontent.com/1239245/185304085-5cd420ca-a8e6-420c-bdb3-4a652ae50d2a.png"> | <img width="366" alt="スクリーンショット 0004-08-18 14 51 19" src="https://user-images.githubusercontent.com/1239245/185304116-683180dc-d84f-4a93-862f-8240ed6164cd.png"> |
 