### PR TITLE
fix(hijack_netrw): alternate file may not exist

### DIFF
--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -91,7 +91,7 @@ local hijack_netrw = function()
       vim.schedule(function()
         local bufname = vim.api.nvim_buf_get_name(0)
         if vim.fn.isdirectory(bufname) == 0 then
-          netrw_bufname = vim.fn.expand "#:p:h"
+          _, netrw_bufname = pcall(vim.fn.expand, "#:p:h")
           return
         end
 


### PR DESCRIPTION
Wrap expand in pcall as it seemingly
does not exist in scenarios for which
file-browser should not be opened anyways.

Closes #179 