### PR TITLE
fix(hijack_netrw): netrw telescope-file-browser entanglement

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: JohnnyMorganz/stylua-action@1.0.0
+      - uses: JohnnyMorganz/stylua-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # CLI arguments

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -83,9 +83,20 @@ config.values = _TelescopeFileBrowserConfig
 
 local hijack_netrw = function()
   local netrw_bufname
-  vim.api.nvim_create_augroup("FileExplorer", { clear = true })
+
+  -- clear FileExplorer appropriately to prevent netrw from launching on folders
+  -- netrw may or may not be loaded before telescope-file-browser config
+  -- conceptual credits to nvim-tree
+  pcall(vim.api.nvim_clear_autocmds, { group = "FileExplorer" })
+  vim.api.nvim_create_autocmd("VimEnter", {
+    pattern = "*",
+    once = true,
+    callback = function()
+      pcall(vim.api.nvim_clear_autocmds, { group = "FileExplorer" })
+    end,
+  })
   vim.api.nvim_create_autocmd("BufEnter", {
-    group = "FileExplorer",
+    group = vim.api.nvim_create_augroup("telescope-file-browser.nvim", { clear = true }),
     pattern = "*",
     callback = function()
       vim.schedule(function()
@@ -111,7 +122,7 @@ local hijack_netrw = function()
         }
       end)
     end,
-    desc = "Telescope file-browser replacement for netrw",
+    desc = "telescope-file-browser.nvim replacement for netrw",
   })
 end
 

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,4 +1,4 @@
-local docgen = require('docgen')
+local docgen = require "docgen"
 
 local docs = {}
 
@@ -17,7 +17,7 @@ docs.test = function()
     docgen.write(input_file, output_file_handle)
   end
 
-  output_file_handle:write(" vim:tw=78:ts=8:ft=help:norl:\n")
+  output_file_handle:write " vim:tw=78:ts=8:ft=help:norl:\n"
   output_file_handle:close()
   vim.cmd [[checktime]]
 end
@@ -25,5 +25,3 @@ end
 docs.test()
 
 return docs
-
-


### PR DESCRIPTION
problem: netrw may (or may not be) sourced before
telescope-file-browser configuration.
Therefore "FileExplorer" augroup may not
be cleared and not get set appropriately
solution: clear FileExplorer appropriately and
create new augroup for telescope-file-browser

closes #182 

@qRoC could you please test whether it fixes the issue for you?


