### PR TITLE
feat: supress warning if a broken link is found

### DIFF
--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -194,7 +194,10 @@ local make_entry = function(opts)
       local stat = vim.loop.fs_stat(t.value)
       t.stat = vim.F.if_nil(stat, false)
       if not t.stat then
-        log.warn("Unable to get stat for " .. t.value)
+        local lstat = vim.F.if_nil(vim.loop.fs_lstat(t.value), false)
+        if not lstat then
+            log.warn("Unable to get stat for " .. t.value)
+        end
       end
       return stat
     end

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -196,7 +196,7 @@ local make_entry = function(opts)
       if not t.stat then
         local lstat = vim.F.if_nil(vim.loop.fs_lstat(t.value), false)
         if not lstat then
-            log.warn("Unable to get stat for " .. t.value)
+          log.warn("Unable to get stat for " .. t.value)
         end
       end
       return stat


### PR DESCRIPTION
Thanks for all your work on this plugin! I've been using this for a while now, and I have a minor usability suggestion:

Every time I open `telescope-file-browser` in a directory with a broken symlink, the logger raises a warning, which might be a bit unnecessary. Plus now with `vim.o.cmdheight = 0`, this results in needing to press `<Enter>` again to clear the logger warning before using the file browser. 

I suggest just adding one more `if` statement to check if it's a link, and not to send through a warning to the logger if that's the case. If `fs_lstat()` returns an invalid result, then raise the warning as before.

A quick demo after running `:!ln -s /tmp/this/doesnt/exist ./broken_link`:

![Screenshot from 2022-10-11 21-55-49](https://user-images.githubusercontent.com/16640474/195072340-f0a125a6-98e7-4b3b-901a-72d4227aeea3.png)

No stats or file preview are displayed for the broken link, and the logger is silent because this is anticipated with this change
