### PR TITLE
feat(toggle_gitignore): Toggle gitignore files/folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Note: `path` corresponds to the folder the `file_browser` is currently in.
 | `<C-t>/t`       |change_cwd              |Change nvim's cwd to selected folder/file(parent)                                |
 | `<C-f>/f`       |toggle_browser          |Toggle between file and folder browser                                           |
 | `<C-h>/h`       |toggle_hidden           |Toggle hidden files/folders                                                      |
+| `<C-u>/u`       |toggle_gitignore        |Toggle files/folders in `.gitignore`                                             |
 | `<C-s>/s`       |toggle_all              |Toggle all entries ignoring `./` and `../`                                       |
 
 `fb_actions.create_from_prompt` requires that your terminal recognizes these keycodes (e.g. kitty). See `:h tui-input` for more information.

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -265,6 +265,15 @@ fb_actions.toggle_hidden({prompt_bufnr}) *telescope-file-browser.actions.toggle_
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+fb_actions.toggle_gitignore({prompt_bufnr}) *telescope-file-browser.actions.toggle_gitignore()*
+    Toggle files and folders in `.gitignore` for
+    |telescope-file-browser.picker.file_browser|.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 fb_actions.open()                      *telescope-file-browser.actions.open()*
     Opens the file or folder with the default application.
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -491,6 +491,15 @@ fb_actions.toggle_hidden = function(prompt_bufnr)
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
 
+--- Toggle files and folders in `.gitignore` for |telescope-file-browser.picker.file_browser|.
+---@param prompt_bufnr number: The prompt bufnr
+fb_actions.toggle_gitignore = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local finder = current_picker.finder
+  finder.respect_gitignore = not finder.respect_gitignore
+  current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+end
+
 --- Opens the file or folder with the default application.<br>
 --- - Notes:
 ---   - map fb_actions.open + fb_actions.close if you want to close the picker post-action

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -25,6 +25,7 @@ _TelescopeFileBrowserConfig = {
       ["<C-t>"] = fb_actions.change_cwd,
       ["<C-f>"] = fb_actions.toggle_browser,
       ["<C-h>"] = fb_actions.toggle_hidden,
+      ["<C-u>"] = fb_actions.toggle_gitignore,
       ["<C-s>"] = fb_actions.toggle_all,
     },
     ["n"] = {
@@ -40,6 +41,7 @@ _TelescopeFileBrowserConfig = {
       ["t"] = fb_actions.change_cwd,
       ["f"] = fb_actions.toggle_browser,
       ["h"] = fb_actions.toggle_hidden,
+      ["u"] = fb_actions.toggle_gitignore,
       ["s"] = fb_actions.toggle_all,
     },
   },


### PR DESCRIPTION
Add functionality to toggle `.gitignore`d files and folders.

Searching ignored files and folders is seldom needed, but it is inconvenient to have to change the Neovim configuration when the need arises.