### PR TITLE
fix(fb_actions.remove): fix incorrect log message prefix

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -427,7 +427,7 @@ fb_actions.remove = function(prompt_bufnr)
   local quiet = current_picker.finder.quiet
   local selections = fb_utils.get_selected_files(prompt_bufnr, true)
   if vim.tbl_isempty(selections) then
-    fb_utils.notify("actions.move", { msg = "No selection to be removed!", level = "WARN", quiet = quiet })
+    fb_utils.notify("actions.remove", { msg = "No selection to be removed!", level = "WARN", quiet = quiet })
     return
   end
 


### PR DESCRIPTION
Should be `actions.remove`, not `actions.move`.