### PR TITLE
fix(actions): over validation of open commands

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -512,6 +512,7 @@ fb_actions.open = function(prompt_bufnr)
       :new({
         command = cmd,
         args = { selection:absolute() },
+        skip_validation = true,
       })
       :start()
   end


### PR DESCRIPTION
On Windows, despite `start` being a vaid built-in command, it is not in the Powershell path and so `:echo executable('start')` returns `0`.

Passing the option `skip_validation = true` to `plenary.job` as all three command options being passed to plenary  for `fb_action.open` should *"always"* be executable and thereby not need validation.

closes #198 