### PR TITLE
feat(file_browser): sync fd for faster support of flags

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -116,8 +116,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                               `false` for unlimited depth
                                               (default: 1)
         {auto_depth}        (boolean|number)  unlimit or set `depth` to
-                                              `auto_depth` on non-empty prompt
-                                              for file_browser
+                                              `auto_depth` & unset grouped on
+                                              prompt for file_browser
         {select_buffer}     (boolean)         select current buffer if
                                               possible; may imply
                                               `hidden=true` (default: false)

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -59,7 +59,7 @@ local fb_picker = {}
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
----@field auto_depth boolean|number: unlimit or set `depth` to `auto_depth` on non-empty prompt for file_browser
+---@field auto_depth boolean|number: unlimit or set `depth` to `auto_depth` & unset grouped on prompt for file_browser
 ---@field select_buffer boolean: select current buffer if possible; may imply `hidden=true` (default: false)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)


### PR DESCRIPTION
sync fd speeds up browsing with
- grouped, gitignore, autodepth etc.

+ Deactivate grouped for auto_depth, really gets in the way with half-way larger projects