### PR TITLE
feat: add option `use_fd` to selectively use `fd`

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -106,8 +106,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                               launched from `path` rather than
                                               `cwd` (default: false)
         {grouped}           (boolean)         group initial sorting by
-                                              directories and then files; uses
-                                              plenary.scandir (default: false)
+                                              directories and then files
+                                              (default: false)
         {files}             (boolean)         start in file (true) or folder
                                               (false) browser (default: true)
         {add_dirs}          (boolean)         whether the file browser shows
@@ -151,6 +151,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {hijack_netrw}      (boolean)         use telescope file browser when
                                               opening directory paths; must be
                                               set on `setup` (default: false)
+        {use_fd}            (boolean)         use `fd` if available over
+                                              `plenary.scandir` (default:
+                                              true)
 
 
 
@@ -423,8 +426,7 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
         {files}             (boolean)  start in file (true) or folder (false)
                                        browser (default: true)
         {grouped}           (boolean)  group initial sorting by directories
-                                       and then files; uses plenary.scandir
-                                       (default: false)
+                                       and then files (default: false)
         {depth}             (number)   file tree depth to display (default: 1)
         {hidden}            (boolean)  determines whether to show hidden files
                                        or not (default: false)
@@ -437,6 +439,8 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
                                        (default: )
         {dir_icon_hl}       (string)   change the highlight group of dir icon
                                        (default: "Default")
+        {use_fd}            (boolean)  use `fd` if available over
+                                       `plenary.scandir` (default: true)
 
 
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -55,7 +55,7 @@ local fb_picker = {}
 ---@field path string: dir to browse files from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd string: dir to browse folders from, `vim.fn.expanded` automatically (default: vim.loop.cwd())
 ---@field cwd_to_path boolean: whether folder browser is launched from `path` rather than `cwd` (default: false)
----@field grouped boolean: group initial sorting by directories and then files; uses plenary.scandir (default: false)
+---@field grouped boolean: group initial sorting by directories and then files (default: false)
 ---@field files boolean: start in file (true) or folder (false) browser (default: true)
 ---@field add_dirs boolean: whether the file browser shows folders (default: true)
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
@@ -72,6 +72,7 @@ local fb_picker = {}
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
 ---@field display_stat boolean|table: ordered stat; see above notes, (default: `{ date = true, size = true }`)
 ---@field hijack_netrw boolean: use telescope file browser when opening directory paths; must be set on `setup` (default: false)
+---@field use_fd boolean: use `fd` if available over `plenary.scandir` (default: true)
 fb_picker.file_browser = function(opts)
   opts = opts or {}
 
@@ -87,6 +88,7 @@ fb_picker.file_browser = function(opts)
   opts.display_stat = vim.F.if_nil(opts.display_stat, { date = true, size = true })
   opts.custom_prompt_title = opts.prompt_title ~= nil
   opts.custom_results_title = opts.results_title ~= nil
+  opts.use_fd = vim.F.if_nil(opts.use_fd, true)
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file


### PR DESCRIPTION
Allows users to disable the usage of `fd` for whatever reason (compatibility issues, etc) through a new `use_fd` option. Default is set to `true`. Closes #212 


I've also been considering adding unit tests for the picker/finders and having an option to disable `fd` will make testing setup easier.