### PR TITLE
fix: entry misalignment with no devicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Plug 'nvim-telescope/telescope-file-browser.nvim'
 
 #### Optional Dependencies
 
-`telescope-file-browser` optionally levers [fd](https://github.com/sharkdp/fd) if installed for more faster and async browsing, most noticeable in larger repositories.
+- `telescope-file-browser` optionally leverages [fd](https://github.com/sharkdp/fd) if installed for more faster and async browsing, most noticeable in larger repositories.
+- [`nvim-web-devicons`](https://github.com/nvim-tree/nvim-web-devicons) for file icons
 
 # Setup and Configuration
 

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -152,6 +152,7 @@ local make_entry = function(opts)
         icon_hl = opts.dir_icon_hl or "Default"
       else
         icon, icon_hl = utils.get_devicons(entry.value, opts.disable_devicons)
+        icon = icon ~= "" and icon or " "
       end
       table.insert(widths, { width = strings.strdisplaywidth(icon) })
       table.insert(display_array, { icon, icon_hl })


### PR DESCRIPTION
When `nvim-web-devicons` is not installed, entries for files fail to compensate for the icon width of directories causing misalignment of the entries for files compared to that of folders.

Before:
![image](https://user-images.githubusercontent.com/66286082/210156660-6eeacdfa-437c-46b6-a0a4-cb7eed65f9e4.png)


After:
![image](https://user-images.githubusercontent.com/66286082/210156641-bec40cfa-a5a1-4545-bbe1-58886c06c93a.png)
