### PR TITLE
feat: add directory hl for directory entries

### DIFF
--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -162,6 +162,7 @@ local make_entry = function(opts)
     if #path_display > opts.file_width then
       path_display = strings.truncate(path_display, opts.file_width, nil, -1)
     end
+    path_display = is_dir and { path_display, "TelescopePreviewDirectory" } or path_display
     table.insert(display_array, entry.stat and path_display or { path_display, "WarningMsg" })
     table.insert(widths, { width = opts.file_width })
     if opts.display_stat then


### PR DESCRIPTION
Closes #230 

@fdschmidt93 Nsing the `TelescopePreviewDirectory` hl for directory entries.
This will actually bring parity in how directories are displayed between the entries, file preview and even netrw's explorer.

![image](https://user-images.githubusercontent.com/66286082/218287506-1602bda4-58fb-4f5e-8fdd-3f7ed9fc0dd9.png)

I think this change is reasonable enough to make it a default behavior without adding any new options.