### PR TITLE
fix(git): git status use `porcelain` flag

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+    "diagnostics.globals": [
+        "vim",
+        "describe",
+        "it"
+    ]
+}

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -46,7 +46,7 @@ end
 local function git_args()
   -- use dot here to also catch renames which also require the old filename
   -- to properly show it as a rename.
-  local args = { "status", "--short", "--", "." }
+  local args = { "status", "--porcelain", "--", "." }
   return args
 end
 
@@ -89,7 +89,7 @@ fb_finders.browse_files = function(opts)
   local git_file_status = {}
   if opts.git_status then
     local git_status, _ = Job:new({ cwd = opts.path, command = "git", args = git_args() }):sync()
-    git_file_status = fb_git.parse_status_output(git_status, opts.path)
+    git_file_status = fb_git.parse_status_output(git_status, opts.cwd)
   end
   if opts.path ~= os_sep and not opts.hide_parent_dir then
     table.insert(data, 1, parent_path)

--- a/lua/telescope/_extensions/file_browser/git.lua
+++ b/lua/telescope/_extensions/file_browser/git.lua
@@ -1,7 +1,5 @@
 local Path = require "plenary.path"
 
-local os_sep = Path.path.sep
-
 local M = {}
 
 -- icon defaults are taken from Telescope git_status icons
@@ -91,18 +89,13 @@ end
 
 --- Returns a map of absolute file path to file status
 ---@param output table: lines of the git status output
----@param cwd string: the path from which the command was triggered
+---@param cwd string: cwd of the picker
 ---@return table: map from absolute file paths to files status
 M.parse_status_output = function(output, cwd)
   local parsed = {}
   for _, value in ipairs(output) do
-    local status = value:sub(1, 2)
-    -- make sure to only get the last file name in the output to catch renames
-    -- which mention first the old and then the new file name. The old filename
-    -- won't be visible in the file browser so we only want the new name.
-    local file = value:reverse():match("([^ ]+)"):reverse()
-    local abs_file = cwd .. os_sep .. file
-    parsed[abs_file] = status
+    local mod, file = value:match "^(..) (.+)$"
+    parsed[Path:new({ cwd, file }):absolute()] = mod
   end
   return parsed
 end

--- a/lua/tests/fb_git_spec.lua
+++ b/lua/tests/fb_git_spec.lua
@@ -1,0 +1,34 @@
+local fb_git = require "telescope._extensions.file_browser.git"
+
+describe("parse_status_output", function()
+  local cwd = "/project/root/dir"
+  it("works in the root dir", function()
+    local git_status = {
+      "M  .gitignore",
+      " M README.md",
+      " M lua/telescope/_extensions/file_browser/finders.lua",
+      "?? lua/tests/",
+    }
+    local expect = {
+      [cwd .. "/.gitignore"] = "M ",
+      [cwd .. "/README.md"] = " M",
+      [cwd .. "/lua/telescope/_extensions/file_browser/finders.lua"] = " M",
+      [cwd .. "/lua/tests/"] = "??",
+    }
+    local actual = fb_git.parse_status_output(git_status, cwd)
+    assert.are.same(expect, actual)
+  end)
+
+  it("works in a sub dir", function()
+    local git_status = {
+      " M lua/telescope/_extensions/file_browser/finders.lua",
+      "?? lua/tests/",
+    }
+    local expect = {
+      [cwd .. "/lua/telescope/_extensions/file_browser/finders.lua"] = " M",
+      [cwd .. "/lua/tests/"] = "??",
+    }
+    local actual = fb_git.parse_status_output(git_status, cwd)
+    assert.are.same(expect, actual)
+  end)
+end)


### PR DESCRIPTION
Change `git status --short -- . ` -> `git status --porcelain -- .`
The `porcelain` flag produces output more suited for consumption by scripts.
> Give the output in an easy-to-parse format for scripts. This is similar to the short output, but will remain stable across Git versions and regardless of user configuration.

This will avoid issues like https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/243

To accommodate this change `fb_git.parse_status_output` now takes the cwd of the picker as opposed to the `path`.
