### PR TITLE
Add 'path_prompt_prefix' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ require("telescope").setup {
       -- browse_folders
       hide_parent_dir = false,
       collapse_dirs = false,
+      path_prompt_prefix = false,
       quiet = false,
       dir_icon = "",
       dir_icon_hl = "Default",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ require("telescope").setup {
       -- browse_folders
       hide_parent_dir = false,
       collapse_dirs = false,
-      path_prompt_prefix = false,
+      prompt_path = false,
       quiet = false,
       dir_icon = "",
       dir_icon_hl = "Default",

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -158,9 +158,6 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {git_status}        (boolean)         show the git status of files
                                               (default: true if `git`
                                               executable can be found)
-        {prompt_path}       (boolean)         Show the current relative path
-                                              from cwd as the prompt prefix.
-                                              (default: false)
 
 
 

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -158,6 +158,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {git_status}        (boolean)         show the git status of files
                                               (default: true if `git`
                                               executable can be found)
+        {prompt_path}       (boolean)         Show the current relative path
+                                              from cwd as the prompt prefix.
+                                              (default: false)
 
 
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -544,7 +544,10 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
 
   finder.path = parent_dir
   fb_utils.redraw_border_title(current_picker)
-  current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+  current_picker:refresh(
+    finder,
+    { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }
+  )
 end
 
 --- Goto working directory of nvim in |telescope-file-browser.picker.file_browser|.
@@ -555,7 +558,10 @@ fb_actions.goto_cwd = function(prompt_bufnr)
   finder.path = vim.loop.cwd()
 
   fb_utils.redraw_border_title(current_picker)
-  current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+  current_picker:refresh(
+    finder,
+    { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }
+  )
 end
 
 --- Change working directory of nvim to the selected file/folder in |telescope-file-browser.picker.file_browser|.
@@ -569,7 +575,10 @@ fb_actions.change_cwd = function(prompt_bufnr)
   vim.cmd("cd " .. finder.path)
 
   fb_utils.redraw_border_title(current_picker)
-  current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+  current_picker:refresh(
+    finder,
+    { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }
+  )
   fb_utils.notify(
     "action.change_cwd",
     { msg = "Set the current working directory!", level = "INFO", quiet = finder.quiet }
@@ -584,7 +593,10 @@ fb_actions.goto_home_dir = function(prompt_bufnr)
   finder.path = vim.loop.os_homedir()
 
   fb_utils.redraw_border_title(current_picker)
-  current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+  current_picker:refresh(
+    finder,
+    { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }
+  )
 end
 
 --- Toggle between file and folder browser for |telescope-file-browser.picker.file_browser|.

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -73,7 +73,10 @@ _TelescopeFileBrowserConfig = {
       finder.files = true
       finder.path = path
       fb_utils.redraw_border_title(current_picker)
-      current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+      current_picker:refresh(
+        finder,
+        { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }
+      )
     end)
     return true
   end,

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -189,6 +189,7 @@ fb_finders.finder = function(opts)
     end,
     prompt_title = opts.custom_prompt_title,
     results_title = opts.custom_results_title,
+    path_prompt_prefix = opts.path_prompt_prefix,
     use_fd = vim.F.if_nil(opts.use_fd, true),
   }, {
     __call = function(self, ...)

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -189,7 +189,7 @@ fb_finders.finder = function(opts)
     end,
     prompt_title = opts.custom_prompt_title,
     results_title = opts.custom_results_title,
-    path_prompt_prefix = opts.path_prompt_prefix,
+    prompt_path = opts.prompt_path,
     use_fd = vim.F.if_nil(opts.use_fd, true),
   }, {
     __call = function(self, ...)

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -91,7 +91,7 @@ fb_picker.file_browser = function(opts)
   opts.custom_results_title = opts.results_title ~= nil
   opts.use_fd = vim.F.if_nil(opts.use_fd, true)
   opts.git_status = vim.F.if_nil(opts.git_status, vim.fn.executable "git" == 1)
-  opts.path_prompt_prefix = vim.F.if_nil(opts.path_prompt_prefix, false)
+  opts.prompt_path = vim.F.if_nil(opts.prompt_path, false)
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
@@ -116,7 +116,7 @@ fb_picker.file_browser = function(opts)
     .new(opts, {
       prompt_title = opts.files and "File Browser" or "Folder Browser",
       results_title = Path:new(opts.path):make_relative(cwd) .. os_sep,
-      prompt_prefix = opts.path_prompt_prefix and (Path:new(opts.path):make_relative(cwd) .. os_sep) or nil,
+      prompt_prefix = fb_utils.relative_path_prefix(opts.finder),
       previewer = conf.file_previewer(opts),
       sorter = conf.file_sorter(opts),
     })

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -74,6 +74,7 @@ local fb_picker = {}
 ---@field hijack_netrw boolean: use telescope file browser when opening directory paths; must be set on `setup` (default: false)
 ---@field use_fd boolean: use `fd` if available over `plenary.scandir` (default: true)
 ---@field git_status boolean: show the git status of files (default: true if `git` executable can be found)
+---@field prompt_path boolean: Show the current relative path from cwd as the prompt prefix. (default: false)
 fb_picker.file_browser = function(opts)
   opts = opts or {}
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -91,6 +91,7 @@ fb_picker.file_browser = function(opts)
   opts.custom_results_title = opts.results_title ~= nil
   opts.use_fd = vim.F.if_nil(opts.use_fd, true)
   opts.git_status = vim.F.if_nil(opts.git_status, vim.fn.executable "git" == 1)
+  opts.path_prompt_prefix = vim.F.if_nil(opts.path_prompt_prefix, false)
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file
@@ -115,6 +116,7 @@ fb_picker.file_browser = function(opts)
     .new(opts, {
       prompt_title = opts.files and "File Browser" or "Folder Browser",
       results_title = Path:new(opts.path):make_relative(cwd) .. os_sep,
+      prompt_prefix = opts.path_prompt_prefix and (Path:new(opts.path):make_relative(cwd) .. os_sep) or nil,
       previewer = conf.file_previewer(opts),
       sorter = conf.file_sorter(opts),
     })

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -125,6 +125,15 @@ fb_utils.redraw_border_title = function(current_picker)
   end
 end
 
+fb_utils.relative_path_prefix = function(finder)
+  local prefix
+  if finder.path_prompt_prefix then
+    prefix = Path:new(finder.path):make_relative(finder.cwd) .. os_sep
+  end
+
+  return prefix
+end
+
 fb_utils.group_by_type = function(tbl)
   table.sort(tbl, function(x, y)
     local x_stat = vim.loop.fs_stat(x)

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -128,8 +128,8 @@ end
 fb_utils.relative_path_prefix = function(finder)
   local prefix
   if finder.prompt_path then
-    local path, _ = Path:new(finder.path):make_relative(finder.cwd):gsub(vim.fn.expand("~"), "~")
-    if path:match("^%w") then
+    local path, _ = Path:new(finder.path):make_relative(finder.cwd):gsub(vim.fn.expand "~", "~")
+    if path:match "^%w" then
       prefix = "./" .. path .. os_sep
     else
       prefix = path .. os_sep

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -127,8 +127,7 @@ end
 
 fb_utils.relative_path_prefix = function(finder)
   local prefix
-  if finder.path_prompt_prefix then
-    prefix = Path:new(finder.path):make_relative(finder.cwd) .. os_sep
+  if finder.prompt_path then
   end
 
   return prefix

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -128,6 +128,12 @@ end
 fb_utils.relative_path_prefix = function(finder)
   local prefix
   if finder.prompt_path then
+    local path, _ = Path:new(finder.path):make_relative(finder.cwd):gsub(vim.fn.expand("~"), "~")
+    if path:match("^%w") then
+      prefix = "./" .. path .. os_sep
+    else
+      prefix = path .. os_sep
+    end
   end
 
   return prefix


### PR DESCRIPTION
If enabled, will update the prompt with the relative path from the CWD. Defaults to `false`
![Screenshot 2023-03-22 at 15 15 01](https://user-images.githubusercontent.com/7228095/226932325-afe50c8d-136e-403c-b28d-6c3f5d081103.png)
![Screenshot 2023-03-22 at 15 15 14](https://user-images.githubusercontent.com/7228095/226932332-5ac54478-b85d-47e4-8507-dd4b57389f61.png)
