### PR TITLE
Add file-descriptor mode column

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ require("telescope").setup {
       quiet = false,
       dir_icon = "",
       dir_icon_hl = "Default",
-      display_stat = { date = true, size = true },
+      display_stat = { date = true, size = true, mode = true },
       hijack_netrw = false,
       use_fd = true,
       git_status = true,

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -82,16 +82,14 @@ local MODE = {
   width = 11,
   right_justify = true,
   display = function(entry)
-    local owner, group, other = string.format("%3o", entry.stat.mode):match("(.)(.)(.)$")
-    return table.concat(
-      {
-        mode_type(entry.lstat.type),
-        mode_perm(owner),
-        mode_perm(group),
-        mode_perm(other),
-        entry.stat.flags ~= 0 and "@" or " "
-      }
-    )
+    local owner, group, other = string.format("%3o", entry.stat.mode):match "(.)(.)(.)$"
+    return table.concat {
+      mode_type(entry.lstat.type),
+      mode_perm(owner),
+      mode_perm(group),
+      mode_perm(other),
+      entry.stat.flags ~= 0 and "@" or " ",
+    }
   end,
   hl = "TelescopePreviewWrite",
 }
@@ -254,7 +252,7 @@ local make_entry = function(opts)
 
     -- stat may be false meaning file not found / unavailable, e.g. broken symlink
     if entry.stat and opts.display_stat then
-      for _, stat in ipairs({ "mode", "size", "date" }) do
+      for _, stat in ipairs { "mode", "size", "date" } do
         local v = opts.display_stat[stat]
 
         if v then

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -70,7 +70,7 @@ local fb_picker = {}
 ---@field quiet boolean: surpress any notification from file_brower actions (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
----@field display_stat boolean|table: ordered stat; see above notes, (default: `{ date = true, size = true }`)
+---@field display_stat boolean|table: ordered stat; see above notes, (default: `{ date = true, size = true, mode = true }`)
 ---@field hijack_netrw boolean: use telescope file browser when opening directory paths; must be set on `setup` (default: false)
 ---@field use_fd boolean: use `fd` if available over `plenary.scandir` (default: true)
 ---@field git_status boolean: show the git status of files (default: true if `git` executable can be found)
@@ -87,7 +87,7 @@ fb_picker.file_browser = function(opts)
   opts.quiet = vim.F.if_nil(opts.quiet, false)
   opts.hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false)
   opts.select_buffer = vim.F.if_nil(opts.select_buffer, false)
-  opts.display_stat = vim.F.if_nil(opts.display_stat, { date = true, size = true })
+  opts.display_stat = vim.F.if_nil(opts.display_stat, { mode = true, date = true, size = true })
   opts.custom_prompt_title = opts.prompt_title ~= nil
   opts.custom_results_title = opts.results_title ~= nil
   opts.use_fd = vim.F.if_nil(opts.use_fd, true)


### PR DESCRIPTION
<img width="1016" alt="Screenshot 2023-03-23 at 22 14 47" src="https://user-images.githubusercontent.com/7228095/227364008-8e4b5306-e7ba-418f-b3a7-b363ff103169.png">
<img width="1011" alt="Screenshot 2023-03-23 at 22 18 34" src="https://user-images.githubusercontent.com/7228095/227364943-ff0b29e5-0469-4c15-b213-b642a6e37ad2.png">
<img width="1012" alt="Screenshot 2023-03-23 at 22 18 21" src="https://user-images.githubusercontent.com/7228095/227364966-ff42e459-5cc1-4882-a380-f758d8c02804.png">

I noticed that the order of the columns was being shuffled every time you restart neovim, so I changed the iterator slightly so the order is consistent every time. 

I also added `entry.lstat` to be able to accurately display if a fd is a symlink or not, since `stat` _follows_ links.

Finally, `@` is appended to flagged fd's.