### PR TITLE
Add action "backspace" for insert mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ require("telescope").setup {
           ["<C-f>"] = fb_actions.toggle_browser,
           ["<C-h>"] = fb_actions.toggle_hidden,
           ["<C-s>"] = fb_actions.toggle_all,
+          ["<bs>"] = fb_actions.backspace,
         },
         ["n"] = {
           ["c"] = fb_actions.create,
@@ -205,6 +206,7 @@ Alternatively, you can also access the picker as a function via `require "telesc
 | `<C-s>/s`       | toggle_all           | Toggle all entries ignoring `./` and `../`                                       |
 | `<Tab>`         | see `telescope.nvim` | Toggle selection and move to next selection                                      |
 | `<S-Tab>`       | see `telescope.nvim` | Toggle selection and move to prev selection                                      |
+| `<bs>/`         | backspace            | With an empty prompt, goes to parent dir. Otherwise acts normally                |
 
 `fb_actions.create_from_prompt` requires that your terminal recognizes these keycodes (e.g. kitty). See `:h tui-input` for more information.
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -718,5 +718,16 @@ fb_actions.sort_by_date = function(prompt_bufnr)
   end)
 end
 
+--- If the prompt is empty, goes up to parent dir. Otherwise, acts as normal.
+fb_actions.backspace = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+
+  if current_picker:_get_prompt() == "" then
+    fb_actions.goto_parent_dir(prompt_bufnr, true)
+  else
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<bs>", true, false, true), "tn", true)
+  end
+end
+
 fb_actions = transform_mod(fb_actions)
 return fb_actions

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -719,11 +719,11 @@ fb_actions.sort_by_date = function(prompt_bufnr)
 end
 
 --- If the prompt is empty, goes up to parent dir. Otherwise, acts as normal.
-fb_actions.backspace = function(prompt_bufnr)
+fb_actions.backspace = function(prompt_bufnr, bypass)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
 
   if current_picker:_get_prompt() == "" then
-    fb_actions.goto_parent_dir(prompt_bufnr, true)
+    fb_actions.goto_parent_dir(prompt_bufnr, bypass)
   else
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<bs>", true, false, true), "tn", true)
   end

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -725,7 +725,7 @@ fb_actions.backspace = function(prompt_bufnr, bypass)
   if current_picker:_get_prompt() == "" then
     fb_actions.goto_parent_dir(prompt_bufnr, bypass)
   else
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<bs>", true, false, true), "tn", true)
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<bs>", true, false, true), "tn", false)
   end
 end
 

--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -26,6 +26,7 @@ _TelescopeFileBrowserConfig = {
       ["<C-f>"] = fb_actions.toggle_browser,
       ["<C-h>"] = fb_actions.toggle_hidden,
       ["<C-s>"] = fb_actions.toggle_all,
+      ["<bs>"] = fb_actions.backspace,
     },
     ["n"] = {
       ["c"] = fb_actions.create,

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -44,6 +44,7 @@ local fb_picker = {}
 ---   - `<C-f>/f`: Toggle between file and folder browser
 ---   - `<C-h>/h`: Toggle hidden files/folders
 ---   - `<C-s>/s`: Toggle all entries ignoring `./` and `../`
+---   - `<bs>/`  : Goes to parent dir if prompt is empty, otherwise acts normally
 --- - display_stat:
 ---   - A table that can currently hold `date` and/or `size` as keys -- order matters!
 ---   - To opt-out, you can pass { display_stat = false }; sorting by stat works regardlessly


### PR DESCRIPTION
This one is pretty simple, and if I'm being honest, stolen straight from emacs' `dired`:
In insert mode, If the prompt is empty and the user types `<bs>`, go to parent dir. If there _is_ any user input in the prompt, then behave as normal. 

This pairs very nicely with the new path_prompt feature.

https://user-images.githubusercontent.com/7228095/227717450-1113e881-4eca-4a0f-b0e8-1ac2b9f587a9.mov

