### PR TITLE
feat(actions): goto_parent_dir selection original dir entry

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -148,7 +148,7 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
                                               dir icon (default: "Default")
         {display_stat}      (boolean|table)   ordered stat; see above notes,
                                               (default: `{ date = true, size =
-                                              true }`)
+                                              true, mode = true }`)
         {hijack_netrw}      (boolean)         use telescope file browser when
                                               opening directory paths; must be
                                               set on `setup` (default: false)

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -107,7 +107,6 @@ fb_actions.create = function(prompt_bufnr)
     if file then
       -- values from finder for values don't have trailing os sep for folders
       local path = file:absolute()
-      path = file:is_dir() and path:sub(1, -2) or path
       fb_utils.selection_callback(current_picker, path)
       current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
     end
@@ -531,6 +530,7 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
   local parent_dir = Path:new(finder.path):parent():absolute()
+  local current_dir = Path:new(finder.path):absolute()
 
   if not bypass then
     if vim.loop.cwd() == finder.path then
@@ -544,6 +544,7 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
 
   finder.path = parent_dir
   fb_utils.redraw_border_title(current_picker)
+  fb_utils.selection_callback(current_picker, current_dir)
   current_picker:refresh(
     finder,
     { new_prefix = fb_utils.relative_path_prefix(finder), reset_prompt = true, multi = current_picker._multi }

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -530,7 +530,7 @@ fb_actions.goto_parent_dir = function(prompt_bufnr, bypass)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
   local parent_dir = Path:new(finder.path):parent():absolute()
-  local current_dir = Path:new(finder.path):absolute()
+  local current_dir = finder.path
 
   if not bypass then
     if vim.loop.cwd() == finder.path then

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -115,10 +115,6 @@ local get_fb_prompt = function()
   return prompt_bufnr
 end
 
-local function trim_right_os_sep(path)
-  return path:sub(-1, -1) ~= os_sep and path or path:sub(1, -1 - os_sep_len)
-end
-
 -- Compute total file width of results buffer:
 -- The results buffer typically splits like this with this notation {item, width}
 -- {devicon, 1} { name, variable }, { stat, stat_width, typically right_justify }
@@ -207,7 +203,7 @@ local make_entry = function(opts)
     local icon, icon_hl
     local is_dir = entry.Path:is_dir()
     -- entry.ordinal is path excl. cwd
-    local tail = trim_right_os_sep(entry.ordinal)
+    local tail = fb_utils.trim_right_os_sep(entry.ordinal)
     -- path_display plays better with relative paths
     local path_display = utils.transform_path(opts, tail)
     if is_dir then

--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -180,11 +180,17 @@ fb_utils.notify = function(funname, opts)
   end
 end
 
+-- trim the right most os separator from a path string
+fb_utils.trim_right_os_sep = function(path)
+  return path:sub(-1, -1) ~= os_sep and path or path:sub(1, -1 - #os_sep)
+end
+
 local _get_selection_index = function(path, dir, results)
   local path_dir = Path:new(path):parent():absolute()
+  path = fb_utils.trim_right_os_sep(path)
   if dir == path_dir then
     for i, path_entry in ipairs(results) do
-      if path_entry.value == path then
+      if fb_utils.trim_right_os_sep(path_entry.value) == path then
         return i
       end
     end


### PR DESCRIPTION
Using the `goto_parent_dir` action will now set the picker selection to the directory you just left. 

Additionally, I made a slight refactor/fix so that when you create a directory using the `create` action, the selection is set to the newly created directory. Previously, this was only working for created files.

I have tested these changes against all other actions involving files and folders, and everything works fine except for the `copy` action, which is also broken on the master as well I think