### PR TITLE
fix: entry width calculation with separator

### DIFF
--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -79,6 +79,8 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
       - `<C-f>/f`: Toggle between file and folder browser
       - `<C-h>/h`: Toggle hidden files/folders
       - `<C-s>/s`: Toggle all entries ignoring `./` and `../`
+      - `<bs>/` : Goes to parent dir if prompt is empty, otherwise acts
+        normally
     - display_stat:
       - A table that can currently hold `date` and/or `size` as keys -- order
         matters!
@@ -374,6 +376,11 @@ fb_actions.sort_by_date()      *telescope-file-browser.actions.sort_by_date()*
     Toggle sorting by last change to the entry.
     Note: initially sorts desendingly from most to least recently changed
     entry.
+
+
+
+fb_actions.backspace()            *telescope-file-browser.actions.backspace()*
+    If the prompt is empty, goes up to parent dir. Otherwise, acts as normal.
 
 
 

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -11,6 +11,8 @@ local Path = require "plenary.path"
 local os_sep = Path.path.sep
 local os_sep_len = #os_sep
 
+local sep = " "
+
 local stat_enum = {
   size = fs_stat.size,
   date = fs_stat.date,
@@ -44,8 +46,8 @@ end
 local function compute_file_width(status, opts)
   local total_file_width = vim.api.nvim_win_get_width(status.results_win)
     - #status.picker.selection_caret
-    - (opts.disable_devicons and 0 or 1)
-    - (opts.git_status and 2 or 0)
+    - (opts.disable_devicons and 0 or (1 + #sep))
+    - (opts.git_status and (2 + #sep) or 0)
 
   -- Apply stat defaults:
   -- opts.display_stat can be typically either
@@ -66,8 +68,7 @@ local function compute_file_width(status, opts)
           opts.display_stat[key] = default
         end
         local w = opts.display_stat[key].width or 0
-        -- TODO why 2 not 1? ;)
-        total_file_width = total_file_width - w - 2 -- separator
+        total_file_width = total_file_width - w - #sep
       end
     end
   end
@@ -183,7 +184,7 @@ local make_entry = function(opts)
       prompt_bufnr = get_fb_prompt()
     end
     local displayer = entry_display.create {
-      separator = " ",
+      separator = sep,
       items = widths,
       prompt_bufnr = prompt_bufnr,
     }


### PR DESCRIPTION
Fixes a small error in the entry width calculation related to the separator width.
This was leading to ever worsening trailing spaces at the end of entries as we add more `display_stat` items.

Before:
![image](https://user-images.githubusercontent.com/66286082/228086635-ef8e4297-47e4-47d4-8c89-ebbe9d76f731.png)
After (with fix):
![image](https://user-images.githubusercontent.com/66286082/228086735-82f611dd-1686-4b6d-ad46-8426ddde679d.png)
(btw experimenting with adding owner/group fs_stat info but the width can't be static due to non-deterministic username lengths so not super simple - maybe not worth it)

I've tested this using a mix both options for `git_status` and `disable_devicons` and looks good.