### PR TITLE
fix(git): correctly parse and render renamed/copied status

### DIFF
--- a/lua/telescope/_extensions/file_browser/git.lua
+++ b/lua/telescope/_extensions/file_browser/git.lua
@@ -84,12 +84,13 @@ M.make_display = function(opts, status)
   -- the staged hl group.
   local staged = git_abbrev[status:sub(1, 1)] or { icon = " " }
   local unstaged = git_abbrev[status:sub(2, 2)] or { icon = " " }
+
   return {
     staged.icon .. unstaged.icon,
     function()
       return {
-        { { 0, 1 }, staged.hl or "" },
-        { { 1, 2 }, unstaged.hl or "" },
+        { { 0, #staged.icon }, staged.hl or "" },
+        { { #staged.icon, #staged.icon + #unstaged.icon }, unstaged.hl or "" },
       }
     end,
   }
@@ -103,6 +104,9 @@ M.parse_status_output = function(output, cwd)
   local parsed = {}
   for _, value in ipairs(output) do
     local mod, file = value:match "^(..) (.+)$"
+    if mod:find "[RC]" then
+      file = file:match "^.* -> (.+)$"
+    end
     parsed[Path:new({ cwd, file }):absolute()] = mod
   end
   return parsed

--- a/lua/tests/fb_git_spec.lua
+++ b/lua/tests/fb_git_spec.lua
@@ -31,4 +31,19 @@ describe("parse_status_output", function()
     local actual = fb_git.parse_status_output(git_status, cwd)
     assert.are.same(expect, actual)
   end)
+
+  it("parses renamed and copied status", function()
+    local git_status = {
+      "R  lua/telescope/_extensions/file_browser/stats.lua -> lua/telescope/_extensions/file_browser/fs_stat.lua",
+      "C  lua/telescope/_extensions/file_browser/stats.lua -> lua/telescope/_extensions/file_browser/fs_stat.lua",
+      " M lua/telescope/_extensions/file_browser/make_entry.lua",
+    }
+    local expect = {
+      [cwd .. "/lua/telescope/_extensions/file_browser/fs_stat.lua"] = "R ",
+      [cwd .. "/lua/telescope/_extensions/file_browser/fs_stat.lua"] = "C ",
+      [cwd .. "/lua/telescope/_extensions/file_browser/make_entry.lua"] = " M",
+    }
+    local actual = fb_git.parse_status_output(git_status, cwd)
+    assert.are.same(expect, actual)
+  end)
 end)


### PR DESCRIPTION
Currently renamed/copied status are not being correctly parsed.
```
R lua/telescope/_extensions/file_browser/stats.lua -> lua/telescope/_extensions/file_browser/fs_stat.lua
```