### PR TITLE
feat: separate hidden opts for file/folder browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@
 More demo examples can be found in the [showcase issue](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/53).
 
 ### Table of Contents
-* [Installation](#installation)
-* [Setup and Configuration](#setup-and-configuration)
-* [Usage](#usage)
-* [Mappings](#mappings)
-* [Documentation](#documentation)
-* [Workflow](#workflow)
-* [Multi-Selections](#multi-selections)
-* [File System Operations](#file-system-operations)
-* [Exports](#exports)
-* [Roadmap & Contributing](#roadmap--contributing)
+
+- [Installation](#installation)
+- [Setup and Configuration](#setup-and-configuration)
+- [Usage](#usage)
+- [Mappings](#mappings)
+- [Documentation](#documentation)
+- [Workflow](#workflow)
+- [Multi-Selections](#multi-selections)
+- [File System Operations](#file-system-operations)
+- [Exports](#exports)
+- [Roadmap & Contributing](#roadmap--contributing)
 
 ---
 
@@ -103,7 +104,7 @@ require("telescope").setup {
       depth = 1,
       auto_depth = false,
       select_buffer = false,
-      hidden = false,
+      hidden = { file_browser = false, folder_browser = false },
       -- respect_gitignore
       -- browse_files
       -- browse_folders

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -124,9 +124,10 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {select_buffer}     (boolean)         select current buffer if
                                               possible; may imply
                                               `hidden=true` (default: false)
-        {hidden}            (boolean)         determines whether to show
-                                              hidden files or not (default:
-                                              false)
+        {hidden}            (table|boolean)   determines whether to show
+                                              hidden files or not (default: `{
+                                              file_browser = false,
+                                              folder_browser = false }`)
         {respect_gitignore} (boolean)         induces slow-down w/ plenary
                                               finder (default: false, true if
                                               `fd` available)
@@ -400,11 +401,12 @@ fb_finders.browse_files({opts}) *telescope-file-browser.finders.browse_files()*
         {opts} (table)  options to pass to the finder
 
     Fields: ~
-        {path}   (string)   root dir to browse from
-        {depth}  (number)   file tree depth to display, `false` for unlimited
-                            (default: 1)
-        {hidden} (boolean)  determines whether to show hidden files or not
-                            (default: false)
+        {path}   (string)         root dir to browse from
+        {depth}  (number)         file tree depth to display, `false` for
+                                  unlimited (default: 1)
+        {hidden} (table|boolean)  determines whether to show hidden files or
+                                  not (default: `{ file_browser = false,
+                                  folder_browser = false }`)
 
 
 fb_finders.browse_folders({opts}) *telescope-file-browser.finders.browse_folders()*
@@ -417,10 +419,11 @@ fb_finders.browse_folders({opts}) *telescope-file-browser.finders.browse_folders
         {opts} (table)  options to pass to the finder
 
     Fields: ~
-        {cwd}    (string)   root dir to browse from
-        {depth}  (number)   file tree depth to display (default: 1)
-        {hidden} (boolean)  determines whether to show hidden files or not
-                            (default: false)
+        {cwd}    (string)         root dir to browse from
+        {depth}  (number)         file tree depth to display (default: 1)
+        {hidden} (table|boolean)  determines whether to show hidden files or
+                                  not (default: `{ file_browser = false,
+                                  folder_browser = false }`)
 
 
 fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
@@ -432,31 +435,36 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {path}              (string)   root dir to file_browse from (default:
-                                       vim.loop.cwd())
-        {cwd}               (string)   root dir (default: vim.loop.cwd())
-        {cwd_to_path}       (bool)     folder browser follows `path` of file
-                                       browser
-        {files}             (boolean)  start in file (true) or folder (false)
-                                       browser (default: true)
-        {grouped}           (boolean)  group initial sorting by directories
-                                       and then files (default: false)
-        {depth}             (number)   file tree depth to display (default: 1)
-        {hidden}            (boolean)  determines whether to show hidden files
-                                       or not (default: false)
-        {respect_gitignore} (boolean)  induces slow-down w/ plenary finder
-                                       (default: false, true if `fd`
-                                       available)
-        {hide_parent_dir}   (boolean)  hide `../` in the file browser
-                                       (default: false)
-        {dir_icon}          (string)   change the icon for a directory
-                                       (default: )
-        {dir_icon_hl}       (string)   change the highlight group of dir icon
-                                       (default: "Default")
-        {use_fd}            (boolean)  use `fd` if available over
-                                       `plenary.scandir` (default: true)
-        {git_status}        (boolean)  show the git status of files (default:
-                                       true)
+        {path}              (string)         root dir to file_browse from
+                                             (default: vim.loop.cwd())
+        {cwd}               (string)         root dir (default:
+                                             vim.loop.cwd())
+        {cwd_to_path}       (boolean)        folder browser follows `path` of
+                                             file browser
+        {files}             (boolean)        start in file (true) or folder
+                                             (false) browser (default: true)
+        {grouped}           (boolean)        group initial sorting by
+                                             directories and then files
+                                             (default: false)
+        {depth}             (number)         file tree depth to display
+                                             (default: 1)
+        {hidden}            (table|boolean)  determines whether to show hidden
+                                             files or not (default: `{
+                                             file_browser = false,
+                                             folder_browser = false }`)
+        {respect_gitignore} (boolean)        induces slow-down w/ plenary
+                                             finder (default: false, true if
+                                             `fd` available)
+        {hide_parent_dir}   (boolean)        hide `../` in the file browser
+                                             (default: false)
+        {dir_icon}          (string)         change the icon for a directory
+                                             (default: )
+        {dir_icon_hl}       (string)         change the highlight group of dir
+                                             icon (default: "Default")
+        {use_fd}            (boolean)        use `fd` if available over
+                                             `plenary.scandir` (default: true)
+        {git_status}        (boolean)        show the git status of files
+                                             (default: true)
 
 
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -509,7 +509,16 @@ end
 fb_actions.toggle_hidden = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
-  finder.hidden = not finder.hidden
+
+  if type(finder.hidden) == "boolean" then
+    finder.hidden = not finder.hidden
+  else
+    if finder.files then
+      finder.hidden.file_browser = not finder.hidden.file_browser
+    else
+      finder.hidden.folder_browser = not finder.hidden.folder_browser
+    end
+  end
   current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
 end
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -62,7 +62,7 @@ local fb_picker = {}
 ---@field depth number: file tree depth to display, `false` for unlimited depth (default: 1)
 ---@field auto_depth boolean|number: unlimit or set `depth` to `auto_depth` & unset grouped on prompt for file_browser (default: false)
 ---@field select_buffer boolean: select current buffer if possible; may imply `hidden=true` (default: false)
----@field hidden boolean: determines whether to show hidden files or not (default: false)
+---@field hidden table|boolean: determines whether to show hidden files or not (default: `{ file_browser = false, folder_browser = false }`)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)


### PR DESCRIPTION
Modifies the `hidden` option to support separate `hidden` option for file/folder browser.

```
hidden table|boolean: determines whether to show hidden files or not (default: `{ file_browser = false, folder_browser = false }`)
```

closes #227