### PR TITLE
fix: prevent disallowed directory access

### DIFF
--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -53,6 +53,12 @@ _TelescopeFileBrowserConfig = {
       local current_picker = action_state.get_current_picker(prompt_bufnr)
       local finder = current_picker.finder
       local entry = action_state.get_selected_entry()
+
+      if not vim.loop.fs_access(entry.path, "X") then
+        fb_utils.notify("select", { level = "WARN", msg = "Permission denied" })
+        return
+      end
+
       local path = vim.loop.fs_realpath(entry.path)
 
       if finder.files and finder.collapse_dirs then

--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -220,10 +220,6 @@ local make_entry = function(opts)
     end
 
     if k == "path" then
-      local retpath = t.value
-      if not vim.loop.fs_access(retpath, "R", nil) then
-        retpath = t.value
-      end
       return t.value
     end
 


### PR DESCRIPTION
prevents hard error when trying to enter ("cd" into) directory with no execute permission