### PR TITLE
fix(make_entry): handle lstat access

### DIFF
--- a/lua/telescope/_extensions/file_browser/make_entry.lua
+++ b/lua/telescope/_extensions/file_browser/make_entry.lua
@@ -235,6 +235,7 @@ local make_entry = function(opts)
       local lstat = vim.F.if_nil(vim.loop.fs_lstat(t.value), false)
       if not lstat then
         log.warn("Unable to get stat for " .. t.value)
+        t.lstat = false
       else
         t.lstat = lstat
       end


### PR DESCRIPTION
Accessing of `stat` and `lstat` properties on entries were previously handled poorly leading to stack overflow issues when `fs_stat` and `fs_lstat` returned nothing. This seems to be not an uncommon event on Windows.

One part of the puzzle for #285 