### PR TITLE
remove `--base-directory` fd flag for better compatibility

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -38,7 +38,6 @@ local function fd_file_args(opts)
   local args
   if opts.files then
     args = {
-      "--base-directory=" .. opts.path,
       "--absolute-path",
       "--path-separator=" .. os_sep,
       "--type",
@@ -90,14 +89,14 @@ fb_finders.browse_files = function(opts)
       local entry_maker = opts.entry_maker { cwd = opts.path, git_file_status = {} }
       return async_oneshot_finder {
         fn_command = function()
-          return { command = "fd", args = fd_file_args(opts) }
+          return { command = "fd", args = fd_file_args(opts), cwd = opts.path }
         end,
         entry_maker = entry_maker,
         results = not opts.hide_parent_dir and { entry_maker(parent_path) } or {},
         cwd = opts.path,
       }
     else
-      data = fb_utils.job("fd", fd_file_args(opts))
+      data = fb_utils.job("fd", fd_file_args(opts), opts.path)
     end
   else
     data = scan.scan_dir(opts.path, {


### PR DESCRIPTION
removes the `--base-directory` flag usage and instead passes the cwd for the fd command to job runners.

debian/ubuntu (and other related distros) ship fd version 7.4.0 which doesn't support the `--base-directory` flag.

closes #297 