### PR TITLE
feat(git): error handling when not inside git repo

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -14,6 +14,7 @@ local finders = require "telescope.finders"
 
 local scan = require "plenary.scandir"
 local Path = require "plenary.path"
+local Job = require "plenary.job"
 local os_sep = Path.path.sep
 
 local fb_finders = {}
@@ -109,7 +110,7 @@ fb_finders.browse_files = function(opts)
 
   local git_file_status = {}
   if opts.git_status then
-    local git_status = fb_utils.job("git", git_args(), opts.path)
+    local git_status = Job:new({ cwd = opts.path, command = "git", args = git_args() }):sync()
     git_file_status = fb_git.parse_status_output(git_status, opts.cwd)
   end
   if opts.path ~= os_sep and not opts.hide_parent_dir then


### PR DESCRIPTION
Go back to letting git status command silently error.
Otherwise it loudly errors when given path is not inside a git repo.

fixes #301 