### PR TITLE
fix(git): show status after `cd`

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -111,7 +111,7 @@ fb_finders.browse_files = function(opts)
   local git_file_status = {}
   if opts.git_status then
     local git_status = Job:new({ cwd = opts.path, command = "git", args = git_args() }):sync()
-    git_file_status = fb_git.parse_status_output(git_status, opts.cwd)
+    git_file_status = fb_git.parse_status_output(git_status, opts.git_root)
   end
   if opts.path ~= os_sep and not opts.hide_parent_dir then
     table.insert(data, 1, parent_path)
@@ -184,6 +184,8 @@ fb_finders.finder = function(opts)
     hidden = vim.tbl_extend("keep", hidden, hidden_default)
   end
 
+  local git_root = Job:new({ command = "git", args = { "rev-parse", "--show-toplevel" } }):sync()[1]
+
   return setmetatable({
     cwd_to_path = opts.cwd_to_path,
     cwd = opts.cwd_to_path and opts.path or opts.cwd, -- nvim cwd
@@ -199,7 +201,8 @@ fb_finders.finder = function(opts)
     select_buffer = vim.F.if_nil(opts.select_buffer, false),
     hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false),
     collapse_dirs = vim.F.if_nil(opts.collapse_dirs, false),
-    git_status = vim.F.if_nil(opts.git_status, true),
+    git_status = vim.F.if_nil(opts.git_status, git_root ~= nil),
+    git_root = git_root,
     -- ensure we forward make_entry opts adequately
     entry_maker = vim.F.if_nil(opts.entry_maker, function(local_opts)
       return fb_make_entry(vim.tbl_extend("force", opts, local_opts))


### PR DESCRIPTION
parse `git status --porcelain -- .` based on git toplevel directory stored in new field `git_root`.

closes #309