### PR TITLE
feat: add `no_ignore` option for fd

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ require("telescope").setup {
       select_buffer = false,
       hidden = { file_browser = false, folder_browser = false },
       respect_gitignore = vim.fn.executable "fd" == 1
+      no_ignore = false,
       follow_symlinks = false,
       browse_files = require("telescope._extensions.file_browser.finders").browse_files,
       browse_folders = require("telescope._extensions.file_browser.finders").browse_folders,

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -63,8 +63,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
     List, create, delete, rename, or move files and folders of your cwd.
     Notes
     - Default keymaps in insert/normal mode:
-      - `<cr>` : Opens the currently selected file, or navigates to the
-        currently selected directory
+      - `<cr>` : Opens the currently selected file/directory, or creates
+        whatever is in the prompt
+      - `<s-cr>` : Create path in prompt
       - `/`, `\` : (OS Path separator) When typing filepath, the path separator
         will open a directory like `<cr>`.
       - `<A-c>/c`: Create file/folder at current `path` (trailing path
@@ -133,6 +134,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {respect_gitignore} (boolean)         induces slow-down w/ plenary
                                               finder (default: false, true if
                                               `fd` available)
+        {no_ignore}         (boolean)         disable use of ignore files like
+                                              .gitignore/.ignore/.fdignore
+                                              (default: false, requires `fd`)
         {follow_symlinks}   (boolean)         traverse symbolic links, i.e.
                                               files and folders (default:
                                               false, only works with `fd`)
@@ -150,6 +154,9 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {quiet}             (boolean)         surpress any notification from
                                               file_brower actions (default:
                                               false)
+        {use_ui_input}      (boolean)         Use vim.ui.input() instead of
+                                              vim.fn.input() or
+                                              vim.fn.confirm() (default: true)
         {dir_icon}          (string)          change the icon for a directory
                                               (default: )
         {dir_icon_hl}       (string)          change the highlight group of
@@ -468,6 +475,9 @@ fb_finders.finder({opts})            *telescope-file-browser.finders.finder()*
         {respect_gitignore} (boolean)        induces slow-down w/ plenary
                                              finder (default: false, true if
                                              `fd` available)
+        {no_ignore}         (boolean)        disable use of ignore files like
+                                             .gitignore/.ignore/.fdignore
+                                             (default: false, requires `fd`)
         {follow_symlinks}   (boolean)        traverse symbolic links, i.e.
                                              files and folders (default:
                                              false, only works with `fd`)

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -62,9 +62,13 @@ local function fd_file_args(opts)
   if not opts.respect_gitignore then
     table.insert(args, "--no-ignore-vcs")
   end
+  if opts.no_ignore then
+    table.insert(args, "--no-ignore")
+  end
   if opts.follow_symlinks then
     table.insert(args, "--follow")
   end
+  vim.print(args)
   return args
 end
 
@@ -170,6 +174,7 @@ end
 ---@field depth number: file tree depth to display (default: 1)
 ---@field hidden table|boolean: determines whether to show hidden files or not (default: `{ file_browser = false, folder_browser = false }`)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
+---@field no_ignore boolean: disable use of ignore files like .gitignore/.ignore/.fdignore (default: false, requires `fd`)
 ---@field follow_symlinks boolean: traverse symbolic links, i.e. files and folders (default: false, only works with `fd`)
 ---@field hide_parent_dir boolean: hide `../` in the file browser (default: false)
 ---@field dir_icon string: change the icon for a directory (default: )
@@ -199,6 +204,7 @@ fb_finders.finder = function(opts)
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
     auto_depth = vim.F.if_nil(opts.auto_depth, false), -- depth for file browser
     respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),
+    no_ignore = vim.F.if_nil(opts.no_ignore, false),
     follow_symlinks = vim.F.if_nil(opts.follow_symlinks, false),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode
     grouped = vim.F.if_nil(opts.grouped, false),

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -68,7 +68,6 @@ local function fd_file_args(opts)
   if opts.follow_symlinks then
     table.insert(args, "--follow")
   end
-  vim.print(args)
   return args
 end
 

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -66,6 +66,7 @@ local fb_picker = {}
 ---@field select_buffer boolean: select current buffer if possible; may imply `hidden=true` (default: false)
 ---@field hidden table|boolean: determines whether to show hidden files or not (default: `{ file_browser = false, folder_browser = false }`)
 ---@field respect_gitignore boolean: induces slow-down w/ plenary finder (default: false, true if `fd` available)
+---@field no_ignore boolean: disable use of ignore files like .gitignore/.ignore/.fdignore (default: false, requires `fd`)
 ---@field follow_symlinks boolean: traverse symbolic links, i.e. files and folders (default: false, only works with `fd`)
 ---@field browse_files function: custom override for the file browser (default: |fb_finders.browse_files|)
 ---@field browse_folders function: custom override for the folder browser (default: |fb_finders.browse_folders|)


### PR DESCRIPTION
Adds a new `no_ignore` option (only applicable to fd) which enables fd's `--no-ignore` option

closes #326 