### PR TITLE
fix: augment `attach_mappings` without overwriting defaults

### DIFF
--- a/lua/telescope/_extensions/file_browser/config.lua
+++ b/lua/telescope/_extensions/file_browser/config.lua
@@ -44,7 +44,7 @@ _TelescopeFileBrowserConfig = {
       ["s"] = fb_actions.toggle_all,
     },
   },
-  attach_mappings = function()
+  attach_mappings = function(_, _)
     local entry_is_dir = function()
       local entry = action_state.get_selected_entry()
       return entry and entry.Path:is_dir()
@@ -120,6 +120,15 @@ config.setup = function(opts)
   -- TODO maybe merge other keys as well from telescope.config
   config.values.mappings =
     vim.tbl_deep_extend("force", config.values.mappings, require("telescope.config").values.mappings)
+
+  if opts.attach_mappings then
+    local opts_attach = opts.attach_mappings
+    local default_attach = config.values.attach_mappings
+    opts.attach_mappings = function(prompt_bufnr, map)
+      default_attach(prompt_bufnr, map)
+      return opts_attach(prompt_bufnr, map)
+    end
+  end
   config.values = vim.tbl_deep_extend("force", config.values, opts)
 
   if config.values.hijack_netrw then


### PR DESCRIPTION
closes #321

wraps the default `attach_mapping` with provided `attach_mappings`