### PR TITLE
fix(folder_browser): disable path_separator action

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -811,7 +811,7 @@ fb_actions.path_separator = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local dir = Path:new(current_picker.finder.path .. os_sep .. current_picker:_get_prompt() .. os_sep)
 
-  if dir:exists() and dir:is_dir() then
+  if current_picker.finder.files and dir:exists() and dir:is_dir() then
     fb_actions.open_dir(prompt_bufnr, dir.filename)
   else
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(os_sep, true, false, true), "tn", false)


### PR DESCRIPTION
The `path_separator` action working in the `folder_browser` is probably not the expected behavior since path separators are valid (and arguably common) tokens for searches in this mode.