### PR TITLE
fix(action.move): moving folders

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -346,8 +346,10 @@ fb_actions.move = function(prompt_bufnr)
   local skipped = {}
 
   for idx, selection in ipairs(selections) do
-    -- use vim.fs rather than plenary to fetch basename, more battle-tested
     local old_path_absolute = selection:absolute()
+    if vim.fn.isdirectory(old_path_absolute) then
+      old_path_absolute = vim.fs.dirname(old_path_absolute)
+    end
     local basename = vim.fs.basename(old_path_absolute)
     local new_path = Path:new { target_dir, basename }
     if new_path:exists() then


### PR DESCRIPTION
`vim.fs.basename("/foo/bar/)` returns an empty string. This behavior differs from the unix `basename` program which returns `bar`.

Just need to accommodate for this.