### PR TITLE
Revert "fix(action.move): moving folders (#342)"

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -346,10 +346,8 @@ fb_actions.move = function(prompt_bufnr)
   local skipped = {}
 
   for idx, selection in ipairs(selections) do
+    -- use vim.fs rather than plenary to fetch basename, more battle-tested
     local old_path_absolute = selection:absolute()
-    if vim.fn.isdirectory(old_path_absolute) then
-      old_path_absolute = vim.fs.dirname(old_path_absolute)
-    end
     local basename = vim.fs.basename(old_path_absolute)
     local new_path = Path:new { target_dir, basename }
     if new_path:exists() then


### PR DESCRIPTION
This reverts commit 98101b22402cd6d1c7e9a7e0c4718bfc98cb1625.

See: https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/342#issuecomment-1844091746