### PR TITLE
fix(git): show status for git submodules

### DIFF
--- a/lua/telescope/_extensions/file_browser/git.lua
+++ b/lua/telescope/_extensions/file_browser/git.lua
@@ -1,6 +1,13 @@
 local Path = require "plenary.path"
+local Job = require "plenary.job"
 
 local M = {}
+
+---@param cwd string?
+---@return string?
+M.find_root = function(cwd)
+  return Job:new({ cwd = cwd, command = "git", args = { "rev-parse", "--show-toplevel" } }):sync()[1]
+end
 
 -- icon defaults are taken from Telescope git_status icons
 local icon_defaults = {


### PR DESCRIPTION
Need to compute the git toplevel directory upon changing directories since calling `git status` inside a git submodule will give the status relative to the toplevel directory of the submodule, not the parent toplevel directory. This was causing a bug with bad paths being created for git status changes in submodules.

closes #353