### PR TITLE
feat: mode option for files and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ require("telescope").setup {
       hijack_netrw = false,
       use_fd = true,
       git_status = true,
+      dir_mode = 448, -- decimal for 700
+      file_mode = 420, -- decimal for 644
       mappings = {
         ["i"] = {
           ["<A-c>"] = fb_actions.create,

--- a/doc/telescope-file-browser.txt
+++ b/doc/telescope-file-browser.txt
@@ -176,6 +176,12 @@ fb_picker.file_browser({opts})  *telescope-file-browser.picker.file_browser()*
         {prompt_path}       (boolean)         Show the current relative path
                                               from cwd as the prompt prefix.
                                               (default: false)
+        {dir_mode}          (number)          Mode for createing new
+                                              directories (default: 448 --
+                                              decimal for 700)
+        {file_mode}         (number)          Mode for createing new
+                                              files (default: 420 -- decimal
+                                              for 644)
 
 
 

--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -83,9 +83,9 @@ local create = function(file, finder)
     return
   end
   if not fb_utils.is_dir(file.filename) then
-    file:touch { parents = true }
+    file:touch { mode = finder.file_mode, parents = true }
   else
-    Path:new(file.filename:sub(1, -2)):mkdir { parents = true }
+    Path:new(file.filename:sub(1, -2)):mkdir { mode = finder.dir_mode, parents = true }
   end
   return file
 end

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -183,6 +183,8 @@ end
 ---@field dir_icon_hl string: change the highlight group of dir icon (default: "Default")
 ---@field use_fd boolean: use `fd` if available over `plenary.scandir` (default: true)
 ---@field git_status boolean: show the git status of files (default: true)
+---@field dir_mode number: mode for creating new directores (default: 448 -- decimal for 700)
+---@field file_mode number: mode for creating new files (default: 420 -- decimal for 644)
 fb_finders.finder = function(opts)
   opts = opts or {}
   -- cache entries such that multi selections are maintained across {file, folder}_browsers
@@ -215,6 +217,8 @@ fb_finders.finder = function(opts)
     hide_parent_dir = vim.F.if_nil(opts.hide_parent_dir, false),
     collapse_dirs = vim.F.if_nil(opts.collapse_dirs, false),
     git_status = vim.F.if_nil(opts.git_status, fb_git.find_root(cwd) ~= nil),
+    dir_mode = vim.F.if_nil(opts.dir_mode, 448),
+    file_mode = vim.F.if_nil(opts.file_mode, 420),
     -- ensure we forward make_entry opts adequately
     entry_maker = vim.F.if_nil(opts.entry_maker, function(local_opts)
       return fb_make_entry(vim.tbl_extend("force", opts, local_opts))


### PR DESCRIPTION
Hi! While using this plugin I had problems with the default permissions used to create new folders (`plenary.nvim` uses 0700 to create directories). I could not find any option to change the permissions for newly create directories. Therefore, this PR adds the following options:
- `dir_mode`: the default mode/permissions used to create new directories (default to 448 -- decimal for 700)
- `file_mode`: the default mode/permissions used to create new files (defaults to 420 -- decimal for 644)

I took the defaults from the `Path.mkdir` and `Path.touch` methods from `plenary.nvim`.