### PR TITLE
fix(actions.create): use default mkdir mode 0755

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -85,7 +85,7 @@ local create = function(file, finder)
   if not fb_utils.is_dir(file.filename) then
     file:touch { parents = true }
   else
-    Path:new(file.filename:sub(1, -2)):mkdir { parents = true }
+    Path:new(file.filename:sub(1, -2)):mkdir { parents = true, mode = 493 } -- 493 => decimal for mode 0755
   end
   return file
 end


### PR DESCRIPTION
plenary's default for some reason is 0700.
Changing ours to 0755 to be more consistent with `mkdir` which is also the default for `fs_mkdir` (via `mkdir`).

closes https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/360