### PR TITLE
fix(picker): reject non-dir path option

### DIFF
--- a/lua/telescope/_extensions/file_browser/utils.lua
+++ b/lua/telescope/_extensions/file_browser/utils.lua
@@ -218,6 +218,12 @@ fb_utils.to_absolute_path = function(str)
   if not path:exists() then
     fb_utils.notify("to_absolute_path", { msg = string.format("Given path '%s' doesn't exist", path), level = "WARN" })
     return nil
+  elseif not path:is_dir() then
+    fb_utils.notify(
+      "to_absolute_path",
+      { msg = string.format("Given path '%s' is not a directory", path), level = "WARN" }
+    )
+    return nil
   end
   return path:absolute()
 end


### PR DESCRIPTION
Doing `:Telescope file_browser path=/path/to/some/file.txt` now throws an optional warning (based on "quiet" option) and just opens in file_browser in the cwd.