### PR TITLE
docs(readme): add neovim minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ More demo examples can be found in the [showcase issue](https://github.com/nvim-
 
 ### Table of Contents
 
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Setup and Configuration](#setup-and-configuration)
 - [Usage](#usage)
@@ -20,21 +21,26 @@ More demo examples can be found in the [showcase issue](https://github.com/nvim-
 
 ---
 
+## Requirements
+- Neovim >= **0.9.0**
+- [fd](https://github.com/sharkdp/fd) (optional, for faster browser)
+- git (optional, for display git status)
+
 ## Installation
 
 Install the plugin with your preferred package manager.
 
 ```lua
--- packer
-use {
-    "nvim-telescope/telescope-file-browser.nvim",
-    requires = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
-}
-
 --lazy
 {
     "nvim-telescope/telescope-file-browser.nvim",
     dependencies = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
+}
+
+-- packer
+use {
+    "nvim-telescope/telescope-file-browser.nvim",
+    requires = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
 }
 ```
 
@@ -48,12 +54,6 @@ Plug 'nvim-telescope/telescope-file-browser.nvim'
 ```
 
 </details>
-
-#### Optional Dependencies
-
-- `telescope-file-browser` optionally leverages [fd](https://github.com/sharkdp/fd) if installed for faster, more async browsing
-- [`nvim-web-devicons`](https://github.com/nvim-tree/nvim-web-devicons) for file icons
-- `git` to show the status of files directly in the file browser.
 
 ## Setup and Configuration
 


### PR DESCRIPTION
Need 0.9.0 or higher for `vim.fs` access.