### PR TITLE
feat(file_browser): add support for custom parameters in fd search

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -68,6 +68,12 @@ local function fd_file_args(opts)
   if opts.follow_symlinks then
     table.insert(args, "--follow")
   end
+    if opts.fd_params then
+        for index, param in pairs(opts.fd_params) do
+            table.insert(args, index)
+            table.insert(args, param)
+        end
+    end
   return args
 end
 
@@ -184,6 +190,7 @@ end
 ---@field use_fd boolean: use `fd` if available over `plenary.scandir` (default: true)
 ---@field git_status boolean: show the git status of files (default: true)
 ---@field create_from_prompt boolean: Create file/folder from prompt if no entry selected (default: true)
+---@field fd_params table: additional parameters for `fd` (default: `{}`)
 fb_finders.finder = function(opts)
   opts = opts or {}
   -- cache entries such that multi selections are maintained across {file, folder}_browsers
@@ -231,6 +238,7 @@ fb_finders.finder = function(opts)
     results_title = opts.custom_results_title,
     prompt_path = opts.prompt_path,
     use_fd = vim.F.if_nil(opts.use_fd, true),
+    fd_params = vim.tbl_deep_extend("force", {}, opts.fd_params or {})
   }, {
     __call = function(self, ...)
       if self.files and self.auto_depth then

--- a/lua/telescope/_extensions/file_browser/picker.lua
+++ b/lua/telescope/_extensions/file_browser/picker.lua
@@ -82,6 +82,7 @@ local fb_picker = {}
 ---@field git_status boolean: show the git status of files (default: true if `git` executable can be found)
 ---@field prompt_path boolean: Show the current relative path from cwd as the prompt prefix. (default: false)
 ---@field create_from_prompt boolean: Create file/folder from prompt if no entry selected (default: true)
+---@field fd_params table: additional parameters for `fd` (default: `{}`)
 fb_picker.file_browser = function(opts)
   opts = opts or {}
 
@@ -101,6 +102,7 @@ fb_picker.file_browser = function(opts)
   opts.git_status = vim.F.if_nil(opts.git_status, vim.fn.executable "git" == 1)
   opts.prompt_path = vim.F.if_nil(opts.prompt_path, false)
   opts.create_from_prompt = vim.F.if_nil(opts.create_from_prompt, true)
+  opts.fd_params = vim.tbl_deep_extend("force", {}, opts.fd_params or {})
 
   local select_buffer = opts.select_buffer and opts.files
   -- handle case that current buffer is a hidden file


### PR DESCRIPTION
Add support for custom parameters in fd search by allowing users to pass in a table of parameters to be included in the fd command. This change provides more flexibility for users who need to customize their search queries in the file browser.

use-case: e.g. max the results on an unlimited depth search:
```
require('telescope').extensions.file_browser.file_browser({
    path = '%:p:h',
    fd_params = {
        ['--max-results'] = 100,
    },
})
```