### PR TITLE
fix: move has_fd check into a function to reduce startup time

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -31,11 +31,11 @@ local function hidden_opts(opts)
 end
 
 local has_fd_cache = nil
-local has_fd = function() 
-    if has_fd_cache == nil then
-        has_fd_cache = vim.fn.executable("fd") == 1
-    end
-    return has_fd_cache
+local has_fd = function()
+  if has_fd_cache == nil then
+    has_fd_cache = vim.fn.executable "fd" == 1
+  end
+  return has_fd_cache
 end
 
 local use_fd = function(opts)

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -30,8 +30,8 @@ local function hidden_opts(opts)
   end
 end
 
-local has_fd = vim.fn.executable "fd" == 1
 local use_fd = function(opts)
+  local has_fd = vim.fn.executable "fd" == 1
   return opts.use_fd and has_fd
 end
 
@@ -206,7 +206,7 @@ fb_finders.finder = function(opts)
     hidden = hidden,
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
     auto_depth = vim.F.if_nil(opts.auto_depth, false), -- depth for file browser
-    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd),
+    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, use_fd),
     no_ignore = vim.F.if_nil(opts.no_ignore, false),
     follow_symlinks = vim.F.if_nil(opts.follow_symlinks, false),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -30,9 +30,16 @@ local function hidden_opts(opts)
   end
 end
 
+local has_fd_cache = nil
+local has_fd = function() 
+    if has_fd_cache == nil then
+        has_fd_cache = vim.fn.executable("fd") == 1
+    end
+    return has_fd_cache
+end
+
 local use_fd = function(opts)
-  local has_fd = vim.fn.executable "fd" == 1
-  return opts.use_fd and has_fd
+  return opts.use_fd and has_fd()
 end
 
 local function fd_file_args(opts)
@@ -206,7 +213,7 @@ fb_finders.finder = function(opts)
     hidden = hidden,
     depth = vim.F.if_nil(opts.depth, 1), -- depth for file browser
     auto_depth = vim.F.if_nil(opts.auto_depth, false), -- depth for file browser
-    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, use_fd),
+    respect_gitignore = vim.F.if_nil(opts.respect_gitignore, has_fd()),
     no_ignore = vim.F.if_nil(opts.no_ignore, false),
     follow_symlinks = vim.F.if_nil(opts.follow_symlinks, false),
     files = vim.F.if_nil(opts.files, true), -- file or folders mode


### PR DESCRIPTION
`vim.fn.executable "fd"` takes up to one second, at least on WSL 2 + NixOS setup I'm using. In this PR I'm moving the invocation into a lazy function so that when the plugin is loaded at startup the user wouldn't incur this cost right away.