### PR TITLE
fix: handle willRenameFiles result.result nil

### DIFF
--- a/lua/telescope/_extensions/file_browser/lsp.lua
+++ b/lua/telescope/_extensions/file_browser/lsp.lua
@@ -166,7 +166,7 @@ local function will_do(method, files, param_fn)
         fb_utils.notify("lsp", { msg = reason, level = "WARN" })
       elseif result.err ~= nil then
         fb_utils.notify("lsp", { msg = result.err, level = "WARN" })
-      else
+      elseif result.result ~= nil then
         vim.lsp.util.apply_workspace_edit(result.result, client.offset_encoding)
       end
     end


### PR DESCRIPTION
Now [will_do](https://github.com/nvim-telescope/telescope-file-browser.nvim/blob/a46780830b576049c675680650f773bedfa8677a/lua/telescope/_extensions/file_browser/lsp.lua#L170) can send `result.result=nil` to `vim.lsp.util.apply_workspace_edit` which expect not nil `WorkspaceEdit`. In some cases (for example when a rust analyzer is enabled) it leads to error.
Be [lsp spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) willRenameFiles can return an empty `result.result`. So I added handling of this case.  Also, it doesn't look like an error, so there is no error message.