### PR TITLE
feat:  support for creating multiple files using pattern.

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -93,6 +93,33 @@ local create = function(file, finder)
   return file
 end
 
+local function create_items(input, finder)
+  if not input then
+    return
+  end
+  local prefix, middle, suffix = input:match "^(.-){(.-)}(.-)$"
+  local files = {}
+
+  if not (prefix and middle and suffix) then
+    local file = create(input, finder)
+    if file then
+      table.insert(files, file)
+    end
+    return files
+  end
+
+  local file_names = vim.split(middle, ",", { plain = true })
+  for _, file_name in ipairs(file_names) do
+    local resolved_path = prefix .. file_name .. suffix
+    local file = create(resolved_path, finder)
+    if file then
+      table.insert(files, file)
+    end
+  end
+
+  return files
+end
+
 local function newly_created_root(path, cwd)
   local idx
   local parents = path:parents()
@@ -149,11 +176,13 @@ fb_actions.create = function(prompt_bufnr)
   local base_dir = get_target_dir(finder) .. os_sep
   get_input({ prompt = "Create: ", default = base_dir, completion = "file" }, function(input)
     vim.cmd [[ redraw ]] -- redraw to clear out vim.ui.prompt to avoid hit-enter prompt
-    local file = create(input, finder)
-    if file then
-      local selection_path = newly_created_root(file, base_dir)
-      if selection_path then
-        fb_utils.selection_callback(current_picker, selection_path)
+    local files = create_items(input, finder)
+    if files and #files > 0 then
+      for _, file in pairs(files) do
+        local selection_path = newly_created_root(file, base_dir)
+        if selection_path then
+          fb_utils.selection_callback(current_picker, selection_path)
+        end
       end
       current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
     end
@@ -168,12 +197,12 @@ fb_actions.create_from_prompt = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
   local input = (finder.files and finder.path or finder.cwd) .. os_sep .. current_picker:_get_prompt()
-  local file = create(input, finder)
-  if file then
-    -- pretend new file path is entry
-    local path = file:absolute()
-    state.set_global_key("selected_entry", { path, value = path, path = path, Path = file })
-    -- select as if were proper entry to support eg changing into created folder
+  local files = create_items(input, finder)
+  if files and #files > 0 then
+    for _, file in ipairs(files) do
+      local path = file:absolute()
+      state.set_global_key("selected_entry", { path, value = path, path = path, Path = file })
+    end
     action_set.select(prompt_bufnr, "default")
   end
 end


### PR DESCRIPTION
# Added Multi-File Creation Functionality

   - Now possible to create multiple files at once using the pattern {file1,file2,file3}.ext.
   - Updated action.create and action.create_from_prompt to use create_items for handling multiple files.
   - This allows generating several files in one go.
 [example](https://github.com/user-attachments/assets/20756c25-d18d-4074-8fd8-e8b87139c460)



### Why This Matters:

This change speeds up the workflow by reducing the steps needed to create multiple files. It makes the process quicker and simpler, cutting down repetitive tasks.

I’m not a expert, but I believe this feature will make things easier for others and improve file management efficiency.


