### PR TITLE
fix(git.lua): git_status not working on Windows

### DIFF
--- a/lua/telescope/_extensions/file_browser/git.lua
+++ b/lua/telescope/_extensions/file_browser/git.lua
@@ -114,7 +114,7 @@ M.parse_status_output = function(output, cwd)
     if mod:find "[RC]" then
       file = file:match "^.* -> (.+)$"
     end
-    parsed[Path:new({ cwd, file }):absolute()] = mod
+    parsed[Path:new({ cwd, file }):absolute():gsub("/", package.config:sub(1, 1))] = mod
   end
   return parsed
 end


### PR DESCRIPTION
- Git status display does not work on windows system

In the `mt.__index` function in the `make_entry.lua` file `t.value` returns a windows-compatible path
 
```text
“F:Code\05-other\nvim\min.lua”
```

while the array created with the `parse_status_output` function returns array keys of the following form

```
{
  [“F:Code/05-other/nvim\\.repro/”] = “??”,
  [“F:Code/05-other/nvim\\min.lua”] = “??”
}
```

What causes the problem

I propose this modification to solve the problem.

I hope I've been able to help and thank you for reading.