### PR TITLE
Make folder browser respect depth when using fd

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -51,14 +51,14 @@ local function fd_file_args(opts)
       table.insert(args, "--type")
       table.insert(args, "directory")
     end
-    if type(opts.depth) == "number" then
-      table.insert(args, "--maxdepth")
-      table.insert(args, opts.depth)
-    end
   else
     args = { "--type", "directory", "--absolute-path" }
   end
 
+  if type(opts.depth) == "number" then
+    table.insert(args, "--maxdepth")
+    table.insert(args, opts.depth)
+  end  
   if hidden_opts(opts) then
     table.insert(args, "--hidden")
   end


### PR DESCRIPTION
It's rather silly that depth is only respected when in the file browser. Allowing depth to be used in the folder browser should be allowed. I think the plenary version should be changed as well, so I have [420](https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/420) out there as well, and we can merge one of these and close the other