### PR TITLE
Change folder browser to respect depth

### DIFF
--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -73,14 +73,7 @@ local function fd_file_args(opts)
   end
   return args
 end
-
-local function scandir_file_args(opts)
-  local args = {
-      add_dirs = opts.add_dirs,
-      depth = opts.depth,
-      hidden = hidden_opts(opts),
-      respect_gitignore = opts.respect_gitignore,
-    }
+  
 local function git_args()
   -- use dot here to also catch renames which also require the old filename
   -- to properly show it as a rename.
@@ -159,17 +152,12 @@ fb_finders.browse_folders = function(opts)
       cwd = cwd,
     }
   else
-    local scan_args = {
+    local data = scan.scan_dir(cwd, {
       hidden = hidden_opts(opts),
       only_dirs = true,
       respect_gitignore = opts.respect_gitignore,
-    }
-    
-    if type(opts.depth) == "number" then
-      scan_args.depth = opts.depth
-    end
-    
-    local data = scan.scan_dir(cwd, scan_args)
+      depth = opts.depth,
+    })
     table.insert(data, 1, cwd)
     return finders.new_table { results = data, entry_maker = entry_maker }
   end

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -73,7 +73,7 @@ local function fd_file_args(opts)
   end
   return args
 end
-  
+
 local function git_args()
   -- use dot here to also catch renames which also require the old filename
   -- to properly show it as a rename.

--- a/lua/telescope/_extensions/file_browser/finders.lua
+++ b/lua/telescope/_extensions/file_browser/finders.lua
@@ -51,14 +51,14 @@ local function fd_file_args(opts)
       table.insert(args, "--type")
       table.insert(args, "directory")
     end
-    if type(opts.depth) == "number" then
-      table.insert(args, "--maxdepth")
-      table.insert(args, opts.depth)
-    end
   else
     args = { "--type", "directory", "--absolute-path" }
   end
 
+  if type(opts.depth) == "number" then
+    table.insert(args, "--maxdepth")
+    table.insert(args, opts.depth)
+  end
   if hidden_opts(opts) then
     table.insert(args, "--hidden")
   end
@@ -74,6 +74,13 @@ local function fd_file_args(opts)
   return args
 end
 
+local function scandir_file_args(opts)
+  local args = {
+      add_dirs = opts.add_dirs,
+      depth = opts.depth,
+      hidden = hidden_opts(opts),
+      respect_gitignore = opts.respect_gitignore,
+    }
 local function git_args()
   -- use dot here to also catch renames which also require the old filename
   -- to properly show it as a rename.
@@ -152,11 +159,17 @@ fb_finders.browse_folders = function(opts)
       cwd = cwd,
     }
   else
-    local data = scan.scan_dir(cwd, {
+    local scan_args = {
       hidden = hidden_opts(opts),
       only_dirs = true,
       respect_gitignore = opts.respect_gitignore,
-    })
+    }
+    
+    if type(opts.depth) == "number" then
+      scan_args.depth = opts.depth
+    end
+    
+    local data = scan.scan_dir(cwd, scan_args)
     table.insert(data, 1, cwd)
     return finders.new_table { results = data, entry_maker = entry_maker }
   end


### PR DESCRIPTION
I think the folder browser should respect the depth option. I'm currently trying to build a project selector in my nvim, and I need the folder browser to respect the depth if my project select is going to be useful. 

Also the closer the two are to feature parity, the more it makes sense for them to be configurations of the same action. The more differences there are, the more confusing it can be when you expect configuration options to be respected. The only real differences in the search should be that one filters out files and defaults to the cwd.

Yes, I could override the search function, but I think this makes more sense from a users perspective