### PR TITLE
Prevent access of nil value if trying to change_cwd on no selection

### DIFF
--- a/lua/telescope/_extensions/file_browser/actions.lua
+++ b/lua/telescope/_extensions/file_browser/actions.lua
@@ -670,7 +670,9 @@ end
 fb_actions.change_cwd = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local finder = current_picker.finder
-  local entry_path = action_state.get_selected_entry().Path
+  local entry = action_state.get_selected_entry()
+  if not entry then return end
+  local entry_path = entry.Path
   finder.path = entry_path:is_dir() and entry_path:absolute() or entry_path:parent():absolute()
   finder.cwd = finder.path
   vim.cmd("cd " .. finder.path)


### PR DESCRIPTION
If your prompt is garbage (i.e. not a file/dir in your cwd) and try to run `fb_actions.change_cwd`, you get E5108 (attempt to index a nil value).
This code just adds nil-guarding.